### PR TITLE
Log enhancements, more feedback info, flexibility on stop ID entry

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -232,9 +232,14 @@ function getStopsFromAddress(address, callback) {
     });
 }
 
-function processFeedback(feedback, callback, returnHtml) {
+function processFeedback(feedback, req, callback, returnHtml) {
     feedback = feedback.trim();
-    comments('comments').push('['+(new Date().toISOString().replace(/T/, ' ').replace(/\..+/, ''))+']'+(feedback));
+    // comments('comments').push('['+(new Date().toISOString().replace(/T/, ' ').replace(/\..+/, ''))+']'+(feedback));
+    comments('comments').push({ date: (new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '')),
+                                feedback: feedback,
+                                phone: req.body.From,
+                                email: req.body.email,
+                                ip: req.connection.remoteAddress});
     transporter.sendMail({
         to: config.FEEDBACK_EMAIL_TO,
         subject: 'Realtime Bus Feedback',

--- a/lib/index.js
+++ b/lib/index.js
@@ -243,7 +243,7 @@ function processFeedback(feedback, req, callback, returnHtml) {
     transporter.sendMail({
         to: config.FEEDBACK_EMAIL_TO,
         subject: 'Realtime Bus Feedback',
-        text: feedback
+        text: "Feedback: " + feedback + '\n' + "Phone: " + req.body.From + "\n" + "Email: " + req.body.email
     },function(error, response) {
         if (error) {
             console.log(error);

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ function parseInputReturnBusTimes(message, callback, returnHtml) {
     }
 
     if (message.trim().toLowerCase() === 'about') {
-        return resultsHandler(null, 'Get bus ETAs, text the busstop #. Don\'t know the busstop #, text closest street address or cross streets and get up to 5 closest stops within a mile, text back desired 4 digit bustop number. Text \'Feedback: ..\' to send feedback. Made by Code for Anchorage. Have a smartphone: http\:\/\/bus.codeforanchorage.org');
+        return resultsHandler(null, 'Get bus ETAs, text the busstop # (you can skip leading zeroes). Don\'t know the busstop #, text closest street address or cross streets and get up to 5 closest stops within a mile, text back desired 4 digit bustop number. Text \'Feedback: ..\' to send feedback. Made by Code for Anchorage. Have a smartphone: http\:\/\/bus.codeforanchorage.org');
     }
     if (!message || /^\s*$/.test(message)) {
         return resultsHandler(
@@ -52,9 +52,10 @@ function parseInputReturnBusTimes(message, callback, returnHtml) {
     if (serviceExceptions()) {
         return resultsHandler(null, "No Service - Holiday");
     }
-    if (/^\d+$|^\#\d+$/.test(message)) {
-        // the message is only digits or # + digits-- assume it's a stop number
-        getStopFromStopNumber(parseInt(message.replace('#','')), resultsHandler);
+    // the message is only digits or # + digits or "stop" + (#) + digits -- assume it's a stop number
+    var stopMessage = message.toLowerCase().replace(/ /g,'').replace("stop",'').replace("#",'');
+    if (/^\d+$/.test(stopMessage)) {
+        getStopFromStopNumber(parseInt(stopMessage), resultsHandler);
     } else {
         // assume the user sent us an intersection or address
         getStopsFromAddress(message, resultsHandler)
@@ -112,7 +113,7 @@ function getStopFromStopNumber(stopId, callback) {
     var busTrackerId = stop_number_lookup[stopId];
     console.log('Stop id = ' + stopId + ' => bus tracker id = ' + busTrackerId);
     if (!busTrackerId) {
-        callback(null, 'Invalid stop number.\nPlease enter the 4-digit stop number on the Bus Stop sign.');
+        callback(null, 'Invalid stop number.\nPlease enter the 4-digit stop number on the Bus Stop sign. You can skip leading zeroes.');
         return;
     }
     getStopFromBusTrackerId(busTrackerId, stopId, callback);
@@ -138,7 +139,7 @@ function formatStopData(jsonData, returnHtml) {
     console.log(jsonData);
     if (jsonData.length > 1) out = 'Enter one of these stop numbers for details:\n\n';
     for (var i=0; i < jsonData.length; i++) {
-        var route = jsonData[i].route.replace(/: (\d*)/, '') + " stop #" + jsonData[i].stopId;
+        var route = jsonData[i].route.replace(/: (\d*)/, '') + " stop " + jsonData[i].stopId;
         if (returnHtml) {
             var ll = stopLatLong(jsonData[i].stopId);
             if (ll) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -67,7 +67,7 @@ router.post('/', function(req, res, next) {
 
 
     if (message.substring(0, config.FEEDBACK_TRIGGER.length).toUpperCase() == config.FEEDBACK_TRIGGER.toUpperCase()) {
-        lib.processFeedback(message.substring(config.FEEDBACK_TRIGGER.length), mySendIt, false);
+        lib.processFeedback(message.substring(config.FEEDBACK_TRIGGER.length), req, mySendIt, false);
         return;
     }
 
@@ -107,7 +107,7 @@ router.get('/byLatLon', function(req, res, next) {
 // feedback form endpoint
 router.post('/feedback', function(req, res, next) {
     var mySendIt = sendIt.bind(null,req,res,next);
-    lib.processFeedback(req.body.comment, mySendIt, true);
+    lib.processFeedback(req.body.comment, req, mySendIt, true);
 });
 
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,7 +8,8 @@ var lib = require('../lib/index');
 var config = require('../lib/config')
 
 
-var db = low('./public/db.json')
+var db = low('./public/db.json');
+var db_private = low('./db_private.json');
 
 // Log format:
 // message is whatever the user sends
@@ -16,8 +17,14 @@ var db = low('./public/db.json')
 // data is the current datetime
 // if it's sent from twiliio, we store a human-readable hash of the #
 function logRequest(entry) {
-    entry.date = new Date()
-    db('requests').push(entry)
+    entry.date = new Date();
+    db_private('requests').push(entry);
+    var entry2 = JSON.parse(JSON.stringify(entry)); // Required because of async mode of lowdb
+    if (entry.phone) {
+        entry2.phone = hashwords.hashStr(entry.phone);
+    }
+    entry2.ip = "";
+    db('requests').push(entry2);
 }
 
 function sendIt(req, res, next, err, data, geocodedAddress, altInput, returnHtml) {
@@ -35,7 +42,7 @@ function sendIt(req, res, next, err, data, geocodedAddress, altInput, returnHtml
     var entry = {
         input: altInput || req.body.Body,
         stop: data.route,
-        phone: hashwords.hashStr(req.body.From),
+        phone: req.body.From,
         ip: req.connection.remoteAddress,
         geocodedAddress: geocodedAddress
     }

--- a/test/test.js
+++ b/test/test.js
@@ -4,21 +4,25 @@ var app = require('../app');
 var http = require('http');
 app.set('port', port);
 var server = http.createServer(app);
+
 var config = require('../lib/config');
 var stop_number_lookup = require('../lib/stop_number_lookup');
+var hashwords = require('hashwords')();
+var fs = require('fs');
+
 
 // Helper functions
 function testFeedback(test, res, feedbackString) {
     test.ok(res.body.indexOf("Thanks for the feedback") > -1, "Test feedback response");
-    var comments = require('../comments.json');
+    var comments = JSON.parse(fs.readFileSync('./comments.json'));
     test.ok(function() {
-        for(var i=0; i < comments.length; i++) {
-            if (comments[i].indexOf(feedbackString) > -1) {
+        for(var i=0; i < comments.comments.length; i++) {
+            if (comments.comments[i].indexOf(feedbackString) > -1) {
                 return true
             }
         }
         return false
-    }, "Test feedback log");
+    } (), "Test feedback log");
     test.done();
 }
 
@@ -33,18 +37,56 @@ function testAddress(test, res, address) {
 }
 
 function testStopId(test, res, stopId) {
-    test.ok(res.body.indexOf("stop #" + stopId) > -1, "Test stop ID entry");
+    test.ok(res.body.indexOf("stop " + stopId) > -1, "Test stop ID entry");
     test.done()
 }
 
 function testOutage(test, res) {
-    console.log(res.body);
     test.ok(res.body.indexOf("Bustracker is down") > -1, "Test outage");
     test.done()
 }
 
+function testLogging(test, res, input, phone) {
+    var db = JSON.parse(fs.readFileSync('./public/db.json'));
+    test.ok(function() {
+        for(var i=0; i < db.requests.length; i++) {
+            if (db.requests[i].input == input ) {
+                if (phone) {
+                    if (db.requests[i].phone == hashwords.hashStr(phone)) {
+                        return true
+                    } else {
+                        return false
+                    }
+                } else {
+                    return true
+                }
+            }
+        }
+        return false
+    } (), "Test public log");
+    db = JSON.parse(fs.readFileSync('./db_private.json'));
+    test.ok(function() {
+        for(var i=0; i < db.requests.length; i++) {
+            console.log(db.requests[i].input);
+            if (db.requests[i].input == input ) {
+                if (phone) {
+                    if (db.requests[i].phone == phone) {
+                        return true
+                    } else {
+                        return false
+                    }
+                } else {
+                    return true
+                }
+            }
+        }
+        return false
+    } (), "Test private log");
+    test.done();
+}
 
-exports.main_group = {
+
+exports.group = {
     // Start server and create client
     setUp: function (done) {
         server.listen(port, '0.0.0.0');
@@ -105,6 +147,54 @@ exports.main_group = {
         });
     },
 
+// Alternate stopId combos (Assume browser same as SMS)
+    test_smsHashStopId: function (test) {
+        for (var stopId in stop_number_lookup) break;
+        var altStopId = "#" + stopId;
+        api.post(test, '/', {
+            data: {Body: altStopId}
+        }, function (res) {
+            testStopId(test, res, stopId)
+        });
+    },
+    test_smsHashSpaceStopId: function (test) {
+        for (var stopId in stop_number_lookup) break;
+        var altStopId = "# " + stopId;
+        api.post(test, '/', {
+            data: {Body: altStopId}
+        }, function (res) {
+            testStopId(test, res, stopId)
+        });
+    },
+    test_smsHashZeroStopId: function (test) {
+        for (var stopId in stop_number_lookup) break;
+        var altStopId = "#00" + stopId;
+        api.post(test, '/', {
+            data: {Body: altStopId}
+        }, function (res) {
+            testStopId(test, res, stopId)
+        });
+    },
+    test_smsStopHashStopId: function (test) {
+        for (var stopId in stop_number_lookup) break;
+        var altStopId = "Stop # " + stopId;
+        api.post(test, '/', {
+            data: {Body: altStopId}
+        }, function (res) {
+            testStopId(test, res, stopId)
+        });
+    },
+    test_smsStopStopId: function (test) {
+        for (var stopId in stop_number_lookup) break;
+        var altStopId = "Stop" + stopId;
+        api.post(test, '/', {
+            data: {Body: altStopId}
+        }, function (res) {
+            testStopId(test, res, stopId)
+        });
+    },
+
+
 // Test about
     test_browserAbout: function (test) {
         api.post(test, '/ajax', {
@@ -121,13 +211,33 @@ exports.main_group = {
         });
     },
 
+// Test logging
+    test_smsLogging: function (test) {
+        var input = (Math.random().toString(36)+'00000000000000000').slice(2, 12);  // Input 12 random characters just to get something logged
+        var phone = "907-555-1212";
+        api.post(test, '/', {
+            data: {Body: input,
+                From: phone}
+        }, function (res) {
+            setTimeout(function () {testLogging(test, res, input, phone)}, 5000);  //Delay to make sure logging saves
+        });
+    },
+    test_browserLogging: function (test) {
+        var input = (Math.random().toString(36)+'00000000000000000').slice(2, 12);  // Input 12 random characters just to get something logged
+        api.post(test, '/ajax', {
+            data: {Body: input}
+        }, function (res) {
+            setTimeout(function () {testLogging(test, res, input)}, 5000);  //Delay to make sure logging saves
+        });
+    },
+
 // Test feedback
     test_browserFeedback: function (test) {
         var feedbackString = "Test Feedback " + (new Date().toISOString());
         api.post(test, '/feedback', {
             data: {comment: feedbackString}
         }, function (res) {
-            testFeedback(test, res, feedbackString)
+            setTimeout(function () {testFeedback(test, res, feedbackString)}, 5000);  //Delay to make sure logging saves
         });
     },
     test_smsFeedback: function (test) {
@@ -135,7 +245,7 @@ exports.main_group = {
         api.post(test, '/', {
             data: {Body: config.FEEDBACK_TRIGGER + feedbackString}
         }, function (res) {
-            testFeedback(test, res, feedbackString)
+            setTimeout(function () {testFeedback(test, res, feedbackString)}, 5000);  //Delay to make sure logging saves
         });
 
     },
@@ -152,30 +262,29 @@ exports.main_group = {
             test.ok(res.body.indexOf("5TH AVENUE") > -1, "Test lat-long");
             test.done()
         });
-    }
-};
+    },
 
-exports.outage_group = {
-    // Start server and create client
-    setUp: function (done) {
-        config.MUNI_URL = "http://bustracker.muni.org/InfoPoint/departure.aspx?stopid=";  //"departures.aspx" spelled wrong
-        console.log(config.MUNI_URL);
-        server.listen(port, '0.0.0.0');
-        api = require('nodeunit-httpclient').create({
-            port: port,
-            status: 200    //Test each response is OK (can override later)
+// Bustracker failure
+    test_browserNetworkFailure: function(test) {
+        config.MUNI_URL = '';
+        for (var stopId in stop_number_lookup) break;
+        api.post(test, '/', {
+            data: {Body: stopId}
+        }, function (res) {
+            testOutage(test, res)
         });
-        done();
     },
-
-    tearDown: function (done) {
-        server.close();
-        done();
+    test_smsNetworkFailure: function(test) {
+        config.MUNI_URL = '';
+        for (var stopId in stop_number_lookup) break;
+        api.post(test, '/', {
+            data: {Body: stopId}
+        }, function (res) {
+            testOutage(test, res)
+        });
     },
-
-
-// Test Muni outage
     test_browserOutage: function(test) {
+        config.MUNI_URL = "http://bustracker.muni.org/InfoPoint/departure.aspx?stopid=";  //"departures.aspx" spelled wrong
         for (var stopId in stop_number_lookup) break;
         api.post(test, '/ajax', {
             data: {Body: stopId}
@@ -184,15 +293,7 @@ exports.outage_group = {
         });
     },
     test_smsOutage: function(test) {
-        for (var stopId in stop_number_lookup) break;
-        api.post(test, '/', {
-            data: {Body: stopId}
-        }, function (res) {
-            testOutage(test, res)
-        });
-    },
-    test_networkFailuer: function(test) {
-        config.MUNI_URL = ''
+        config.MUNI_URL = "http://bustracker.muni.org/InfoPoint/departure.aspx?stopid=";  //"departures.aspx" spelled wrong
         for (var stopId in stop_number_lookup) break;
         api.post(test, '/', {
             data: {Body: stopId}
@@ -200,4 +301,7 @@ exports.outage_group = {
             testOutage(test, res)
         });
     }
+
+
 };
+

--- a/test/test.js
+++ b/test/test.js
@@ -12,12 +12,26 @@ var fs = require('fs');
 
 
 // Helper functions
-function testFeedback(test, res, feedbackString) {
+function testFeedback(test, res, feedbackString, phone, email) {
     test.ok(res.body.indexOf("Thanks for the feedback") > -1, "Test feedback response");
     var comments = JSON.parse(fs.readFileSync('./comments.json'));
     test.ok(function() {
         for(var i=0; i < comments.comments.length; i++) {
-            if (comments.comments[i].indexOf(feedbackString) > -1) {
+            if (comments.comments[i].feedback && comments.comments[i].feedback.indexOf(feedbackString) > -1) {
+                if (phone) {
+                    if (comments.comments[i].phone == phone) {
+                        return true
+                    } else {
+                        return false
+                    }
+                }
+                if (email) {
+                    if (comments.comments[i].email == email) {
+                        return true
+                    } else {
+                        return false
+                    }
+                }
                 return true
             }
         }
@@ -234,18 +248,22 @@ exports.group = {
 // Test feedback
     test_browserFeedback: function (test) {
         var feedbackString = "Test Feedback " + (new Date().toISOString());
+        var email = "test@example.com";
         api.post(test, '/feedback', {
-            data: {comment: feedbackString}
+            data: {comment: feedbackString,
+                   email: email}
         }, function (res) {
-            setTimeout(function () {testFeedback(test, res, feedbackString)}, 5000);  //Delay to make sure logging saves
+            setTimeout(function () {testFeedback(test, res, feedbackString, null, email)}, 5000);  //Delay to make sure logging saves
         });
     },
     test_smsFeedback: function (test) {
         var feedbackString = "Test Feedback " + (new Date().toISOString());
+        var phone = "907-555-1212";
         api.post(test, '/', {
-            data: {Body: config.FEEDBACK_TRIGGER + feedbackString}
+            data: {Body: config.FEEDBACK_TRIGGER + feedbackString,
+                From: phone}
         }, function (res) {
-            setTimeout(function () {testFeedback(test, res, feedbackString)}, 5000);  //Delay to make sure logging saves
+            setTimeout(function () {testFeedback(test, res, feedbackString, phone)}, 5000);  //Delay to make sure logging saves
         });
 
     },

--- a/views/index.jade
+++ b/views/index.jade
@@ -4,11 +4,11 @@ html
         title= title
         style.
             body {
-              font-family: sans-serif;
-              text-align: center;
+                font-family: sans-serif;
+                text-align: center;
             }
             #output {
-              padding-top: 20px;
+                padding-top: 20px;
             }
             button {
                 margin: 20px auto;
@@ -43,9 +43,12 @@ html
         form(method="POST" action="/feedback" style="display:none" id="feedback")
             textarea(name="comment" style="width:300px; height:50px;")
             br
-            input(type="submit")
+            label(for='email') Email (optional)
+            input(type='text', id='email', name='email')
+            br
+            input(type="submit", value="Send Feedback")
 
-        p
+    p
         div
             a(href="http://codeforanchorage.org")
                 img.logo(src="img/cfa.png")
@@ -59,12 +62,12 @@ html
         function showLoading() {
             var elements = ['&bull;', '&nbsp;', '&nbsp;', '&nbsp;']
             interval = window.setInterval(
-                function() {
-                    var output = elements.join('');
-                    outputDiv.innerHTML = output;
-                    elements.unshift(elements.pop());
-                },
-                300
+                    function() {
+                        var output = elements.join('');
+                        outputDiv.innerHTML = output;
+                        elements.unshift(elements.pop());
+                    },
+                    300
             );
         }
 
@@ -127,13 +130,13 @@ html
             showLoading();
 
             navigator.geolocation.getCurrentPosition(
-                showPosition,
-                removeLoading,
-                {
-                    enableHighAccuracy: true,
-                    timeout: 10000,
-                    maximumAge: 60000,
-                }
+                    showPosition,
+                    removeLoading,
+                    {
+                        enableHighAccuracy: true,
+                        timeout: 10000,
+                        maximumAge: 60000,
+                    }
             );
         }
 


### PR DESCRIPTION
Rather large PR:

1) Accepts for stop ID:
      Number
      Number with leading zeroes
      '#' + Number, with and without embedded spaces
     'Stop' + ('#') + Number, with and without embedded spaces

1a) Modified instructions a bit to reflect stop ID options

2) Added a field for 'Email' on browser feedback form

3) Email sent to bus_anchorage account includes email and/or phone number of feedback writer

4) Feedback logged in comments.json is now an object with date, feedback, phone, email, ip address

5) Private log created in root (db_private.json) with un-encrypted phone numbers and ip addresses. IP addresses removed from public log.
