### PR TITLE
Fix log plot by day alignment with AK time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 config.js
 *.swp
+*.DS_Store
 
 public/db.json
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -171,7 +171,7 @@ router.get('/logData', function(req, res, next) {
     var daysBack = req.query.daysBack || config.LOG_DAYS_BACK;
     var type = req.query.type;
     var logData = [];
-    var timezone = moment.tz.zone('America/Anchorage');
+    var timezone = moment.tz.zone(config.TIMEZONE);
     if (type == "hits") {
         var dateTz = null;
         db_private('requests').filter(function(point) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -171,6 +171,7 @@ router.get('/logData', function(req, res, next) {
     var daysBack = req.query.daysBack || config.LOG_DAYS_BACK;
     var type = req.query.type;
     var logData = [];
+    var timezone = moment.tz.zone('America/Anchorage');
     if (type == "hits") {
         var dateTz = null;
         db_private('requests').filter(function(point) {
@@ -190,6 +191,7 @@ router.get('/logData', function(req, res, next) {
             var outPoint = {};
             outPoint.type = hitType;
             outPoint.date = moment.tz(point.date, config.TIMEZONE).unix();
+            outPoint.dateOffset = timezone.offset(outPoint.date*1000)
             outPoint.muniTime = point.muniTime || "";
             outPoint.totalTime = point.totalTime || "";
             outPoint.userId = point.phone ? "phone" + point.phone : "ip"+point.ip;

--- a/views/logplot.jade
+++ b/views/logplot.jade
@@ -118,7 +118,8 @@ html
                         }
                         data.forEach(function(point) {
                             var series = "";
-                            var bucket = (Math.floor(parseInt(point.date + (16*60*60)) / bucketWidth ) * bucketWidth) - (16*60*60); // shift the bucketing to account for UTC
+                                // shift the bucketing to account for UTC
+                                var bucket = ((Math.floor(parseInt((point.date) -(point.dateOffset*60)) / bucketWidth ) * bucketWidth) + (point.dateOffset*60)) ;
                             if (showRT) {
                                 ["totalTime", "muniTime"].forEach(function(t, idx) {
                                     var pt = parseInt(point[t]);

--- a/views/logplot.jade
+++ b/views/logplot.jade
@@ -118,7 +118,7 @@ html
                         }
                         data.forEach(function(point) {
                             var series = "";
-                            var bucket = Math.floor(parseInt(point.date) / bucketWidth) * bucketWidth;
+                            var bucket = Math.floor(parseInt(point.date) / bucketWidth) * bucketWidth + (8*60*60);;
                             if (showRT) {
                                 ["totalTime", "muniTime"].forEach(function(t, idx) {
                                     var pt = parseInt(point[t]);

--- a/views/logplot.jade
+++ b/views/logplot.jade
@@ -118,7 +118,7 @@ html
                         }
                         data.forEach(function(point) {
                             var series = "";
-                            var bucket = Math.floor(parseInt(point.date) / bucketWidth) * bucketWidth + (8*60*60);;
+                            var bucket = (Math.floor(parseInt(point.date + (16*60*60)) / bucketWidth ) * bucketWidth) - (16*60*60); // shift the bucketing to account for UTC
                             if (showRT) {
                                 ["totalTime", "muniTime"].forEach(function(t, idx) {
                                     var pt = parseInt(point[t]);


### PR DESCRIPTION
The script in log plot.jade creates buckets based UTC times so the times get put into bins based on UTC time. This doesn't change the times, but shifts the binning to account for the time zone difference.