### PR TITLE
Fixes logging behind proxy

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ var app = express();
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'jade');
+app.set('trust proxy', true); // client’s IP address will be left-most entry in the X-Forwarded-* header
 require('run-middleware')(app);
 
 // uncomment after placing your favicon in /public

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -175,7 +175,7 @@ function initialize(initFunction){
         // don't log requests for static resources - TODO maybe move this to an argument so it can be set from outside
         if (url.startsWith('/css') || url.startsWith('/javascripts')  || url.startsWith('/img')) return next();
         // don't log requests from Elastic loadbalancer health check
-        if (req.get('user-agent').startsWith('ELB-HealthChecker')) return next();
+        if (req.get('user-agent') && req.get('user-agent').startsWith('ELB-HealthChecker')) return next();
 
         req._startTime = undefined;
         res._startTime = undefined;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -197,7 +197,6 @@ function initialize(initFunction){
                 uuid:         res.session
             }
             logger.info(Object.assign(defaultFields, fields))
-            console.log("ip address:", req.ip)
         })
         next();
     }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -174,6 +174,9 @@ function initialize(initFunction){
         var url = req.originalUrl || req.url;
         // don't log requests for static resources - TODO maybe move this to an argument so it can be set from outside
         if (url.startsWith('/css') || url.startsWith('/javascripts')  || url.startsWith('/img')) return next();
+        // don't log requests from Elastic loadbalancer health check
+        if (req.get('user-agent').startsWith('ELB-HealthChecker')) return next();
+
         req._startTime = undefined;
         res._startTime = undefined;
         markStartTime.call(req);
@@ -188,13 +191,13 @@ function initialize(initFunction){
                 method:       req.method,
                 status:       res.statusCode,
                 url:          url,
-                ip:           req.connection.remoteAddress,
+                ip:           req.ip,
                 timestamp:    new Date().toISOString(),
                 responseTime: getResponseTime(req,res),
                 uuid:         res.session
             }
             logger.info(Object.assign(defaultFields, fields))
-
+            console.log("ip address:", req.ip)
         })
         next();
     }


### PR DESCRIPTION
Sets express trust proxy setting so req.ip will use X-Forwarded-* header per http://expressjs.com/en/guide/behind-proxies.html

Don't log requests from user-agent: ELB-HealthChecker 