### PR TITLE
Fix error catch

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -304,8 +304,12 @@ function sendFBMessage(recipientId, messageText) {
 
     }, function (error, response, body) {
         if (error || (response.statusCode != 200)) {
-            logger.error("Failed calling Send API: ", error.message);
-            logger.error("Failed calling Send API", response.statusCode, response.statusMessage);
+            if (error) {
+                logger.error("Failed calling Send API: ", error.message);
+            }
+            if (response) {
+                logger.error("Failed calling Send API", response.statusCode, response.statusMessage);
+            }
         }
     });
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -305,10 +305,10 @@ function sendFBMessage(recipientId, messageText) {
     }, function (error, response, body) {
         if (error || (response.statusCode != 200)) {
             if (error) {
-                logger.error("Failed calling Send API: ", error.message);
+                logger.error("Failed calling Send API: " + error.message);
             }
             if (response) {
-                logger.error("Failed calling Send API", response.statusCode, response.statusMessage);
+                logger.error("Failed calling Send API: " + response.statusCode + " - " + response.statusMessage);
             }
         }
     });


### PR DESCRIPTION
FB is returning a response <> 200, but the catch and logging are failing because "error" is null. Need to fix this so I can figure out what's going on with the FB API.