### PR TITLE
Sanitize input

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -9,7 +9,7 @@ module.exports = {
     GMAIL_USERNAME: process.env.GMAIL_USERNAME,
     GMAIL_PASSWORD: process.env.GMAIL_PASSWORD,
     SLACK_WEBHOOK: process.env.SLACK_WEBHOOK,
-    GOOGLE_GEOCODE_LOCATION: "Anchorage",
+    GOOGLE_GEOCODE_LOCATION: "Anchorage, Alaska",
 
     TIMEZONE: "America/Anchorage",
     MUNI_URL: process.env.MUNI_URL || "http://bustracker.muni.org/InfoPoint/departures.aspx?stopid=",

--- a/lib/index.js
+++ b/lib/index.js
@@ -318,7 +318,6 @@ function verifyFBRequestSignature(req, res, buf) {
             .digest('hex');
         console.log("Signature: ",signatureHash, " Expected: ", expectedHash);
         if (signatureHash != expectedHash) {
-            console.log("Couldn't validate the FB request signature")
             throw new Error("Couldn't validate the request signature.");
         }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,6 @@ function NotFoundError(message) {
 NotFoundError.prototype = new Error;
 
 function getStopsFromAddress(address){
-
     return exports.getGeocodedAddress(address)
     .then((returnObj) => {
         var geocodedPlace = returnObj.data

--- a/lib/index.js
+++ b/lib/index.js
@@ -318,6 +318,7 @@ function verifyFBRequestSignature(req, res, buf) {
             .digest('hex');
         console.log("Signature: ",signatureHash, " Expected: ", expectedHash);
         if (signatureHash != expectedHash) {
+            console.log("Couldn't validate the FB request signature")
             throw new Error("Couldn't validate the request signature.");
         }
     }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "body-parser": "~1.10.2",
     "cookie-parser": "~1.3.3",
     "debug": "~2.1.1",
+    "emoji-regex": "^6.4.2",
     "express": "~4.11.1",
     "hashwords": "^0.1.2",
     "jade": "~1.9.1",

--- a/routes/index.js
+++ b/routes/index.js
@@ -132,10 +132,13 @@ function askWatson(req, res, next){
  */
 function sanitizeInput(req, res, next) {
     // [TODO: add test for this]
-    // Replace tabs, carriage returns, etc with single space to prevent Watson errors. 
+    // Removes everything after return/carriage-return. 
     // Strip emojis
+
+    var firstLine = req.body.Body.split(/\r\n|\r|\n/, 1)[0].replace(/\t/g, " "); // Split on newline type characters and replace tabs with spaces
     const emoRegex = emojiRegex(); 
-    req.body.Body = req.body.Body.replace(/\s/g, ' ').replace(emoRegex, '');  
+
+    req.body.Body = firstLine.replace(emoRegex, '');  
     next()
     
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,7 +8,7 @@ var fs = require('fs');
 var twilioClient = require('twilio')(config.TWILIO_ACCOUNT_SID, config.TWILIO_AUTH_TOKEN);
 var logger = require('../lib/logger');
 var lowdb_log = require('../lib/lowdb_log_transport');
-var emojiRegex = require('emoji-regex')
+var emojiRegex = require('emoji-regex');
 // Facebook requirements
 var request = require('request');
 var https = require('https');
@@ -130,7 +130,6 @@ function askWatson(req, res, next){
  '[Failed?]Stop Lookup' '[Failed?]Address Lookup', 'Empty Input', 'About', 'Feedback'
 
  */
-
 function sanitizeInput(req, res, next) {
     //[TODO: add test for this]
     // Replace tabs, carriage returns, etc with single space to prevent Watson errors. 
@@ -188,7 +187,7 @@ function aboutResponder(req, res, next){
 
 function stopNumberResponder(req,res, next){
     var input = req.body.Body;
-    var stopRequest = input.toLowerCase().replace(/\s\s+/g,'').replace("stop",'').replace("#",'');
+    var stopRequest = input.toLowerCase().replace(/ /g,'').replace("stop",'').replace("#",'');
     if (/^\d+$/.test(stopRequest)) {
         res.locals.action = 'Stop Lookup';
         lib.getStopFromStopNumber(parseInt(stopRequest))
@@ -361,7 +360,7 @@ router.post('/ajax',
  Routes to allow deep linking and bookmarks via url with
  either address, stop number, or about.
  */
- router.get('/find/about', function(req, res, next) {
+router.get('/find/about', function(req, res, next) {
     res.locals.returnHTML = 1;
     res.locals.action = "About"
     res.render('index');
@@ -380,8 +379,7 @@ router.get('/find/:query', function(req, res, next) {
     stopNumberResponder,
     addressResponder,
     askWatson
-    );
-
+);
 
 //  a browser with location service enabled can hit this
 router.get('/byLatLon', function(req, res, next) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -136,16 +136,13 @@ function askWatson(req, res, next){
 
  */
 function sanitizeInput(req, res, next) {
-    // [TODO: add test for this]
-    // Removes everything after return/carriage-return. 
+    // Removes everything after first return/carriage-return. 
     // Strip emojis
 
     var firstLine = req.body.Body.split(/\r\n|\r|\n/, 1)[0].replace(/\t/g, " "); // Split on newline type characters and replace tabs with spaces
     const emoRegex = emojiRegex(); 
-
     req.body.Body = firstLine.replace(emoRegex, '');  
-    next()
-    
+    next();
 }
 
 function feedbackResponder(req, res, next){

--- a/routes/index.js
+++ b/routes/index.js
@@ -189,7 +189,6 @@ function aboutResponder(req, res, next){
 function stopNumberResponder(req,res, next){
     var input = req.body.Body;
     var stopRequest = input.toLowerCase().replace(/\s\s+/g,'').replace("stop",'').replace("#",'');
-    console.log("stop request", stopRequest)
     if (/^\d+$/.test(stopRequest)) {
         res.locals.action = 'Stop Lookup';
         lib.getStopFromStopNumber(parseInt(stopRequest))

--- a/routes/index.js
+++ b/routes/index.js
@@ -131,7 +131,7 @@ function askWatson(req, res, next){
 
  */
 function sanitizeInput(req, res, next) {
-    //[TODO: add test for this]
+    // [TODO: add test for this]
     // Replace tabs, carriage returns, etc with single space to prevent Watson errors. 
     // Strip emojis
     const emoRegex = emojiRegex(); 

--- a/test/test.js
+++ b/test/test.js
@@ -64,7 +64,7 @@ function testFBMsgResponse(test, message, response) {
         setTimeout(function(){
             FBOut.done();
             if (test) test.done();
-        }, 500);
+        }, 1000);
     });
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -175,7 +175,6 @@ function testLogging(test, input, phone, fbUser) {
     test.done();
 }
 
-
 exports.group = {
     // Start server and create client
     setUp: function (done) {

--- a/test/test.js
+++ b/test/test.js
@@ -64,7 +64,7 @@ function testFBMsgResponse(test, message, response) {
         setTimeout(function(){
             FBOut.done();
             if (test) test.done();
-        }, 1000);
+        }, 1500);
     });
 }
 


### PR DESCRIPTION
This adds a middleware function that replaces extraneous whitespace like carriage returns and tabs with a space to prevent errors from Watson. It also strips (most) emojis from user input. It is using [emoji-regex](https://www.npmjs.com/package/emoji-regex) to identify emojis. emoji-regex is quite active, so hopefully we will be able to stay on top of the emojis as they change by simply updating the package. 

The middleware function is placed after the feedback middleware where line returns and emojis probably don't hurt and might be part of the feedback.