### PR TITLE
Remove depreciated Turf library. Add @turf/helpers and @turf/distance…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ config.js
 *.vscode
 .idea
 public/db.json
-
+.nyc_output/
 comments.json
 
 db_private.json

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,8 @@ var request = require('request')
 var config = require('./config')
 var routeNamesToRouteNumbers = require('./routename_to_routenumber');
 var stop_number_lookup = require('./stop_number_lookup')
-var turf = require('turf')
+var turf_distance = require('@turf/distance')
+var turf = require('@turf/helpers')
 var all_stops = require('../gtfs/geojson/stops.json');
 var exceptions = require('../gtfs/geojson/exceptions.json');
 var moment = require('moment-timezone');
@@ -188,23 +189,21 @@ function stopLatLong(stopid) {
 *
 */
 function findNearestStops(lat, lon) {
-    var point = turf.point([lon, lat]);
-    var buffer = turf.buffer(point, config.NEAREST_BUFFER, 'miles');
-    var nearest_stops = turf.within(all_stops, buffer);
-    var out = nearest_stops.features.map(function(stop){
-        var stopId = stop.properties.stop_id.match(/\d+/g)[0];
-        return { route: stop.properties.name,
-                 stopId: stopId,
-                 distance: turf.distance(point, stop, "miles"),
-                 ll: stopLatLong(stopId)
+    var point = turf.point([+lon, +lat]);
+    var out = all_stops.features.reduce((acc, stop) => {
+        var distance = turf_distance(point, stop, 'miles')
+        if (distance <= 1){
+            let stopId = stop.properties.stop_id;
+            acc.push({ route: stop.properties.name,
+                       stopId: stopId,
+                       distance: distance,
+                       ll: stop.geometry.coordinates[1] + "," + stop.geometry.coordinates[0]
+            });
         }
-    });
-    // returns empty if none found nearby
-    out.sort(function(a, b) {
-        return (a.distance - b.distance)
-    });
-    if (out.length > config.NEAREST_MAX) out = out.slice(0,config.NEAREST_MAX);
-    return out;
+        return acc
+    }, [])
+    .sort((a, b) => (a.distance - b.distance))
+    return out.length > 5 ? out.slice(0,5) : out
 }
 
 function getGeocodedAddress(address) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "homepage": "https://github.com/codeforanchorage/realtime-bus-sms",
   "dependencies": {
+    "@turf/distance": "^4.6.0",
+    "@turf/helpers": "^4.6.0",
     "body-parser": "~1.10.2",
     "cookie-parser": "~1.3.3",
     "debug": "~2.1.1",
@@ -38,8 +40,6 @@
     "rollbar": "^0.6.2",
     "run-middleware": "^0.6.6",
     "serve-favicon": "~2.2.0",
-    "turf": "~1.4.0",
-    "turf-nearest": "~1.0.2",
     "twilio": "^3.3.0-edge",
     "universal-analytics": "^0.4.8",
     "watson-developer-cloud": "^2.9.1",

--- a/test/test.js
+++ b/test/test.js
@@ -235,7 +235,7 @@ exports.group = {
             test.ok(spy.called && spy.args[0][0] == 1066, "Test Browser Emoji Removal From Stop Number");
             lib.getStopFromStopNumber.restore();
             test.done();
-        }); 
+        });
     },
     test_emojiRemovalSMSStopNumber: function(test) {
         var input = "1066👌"
@@ -274,7 +274,7 @@ exports.group = {
             test.ok(spy.called && spy.args[0][0] == "5th and G Street", "Test Browser Removal of multi-line input");
             lib.getStopsFromAddress.restore();
             test.done();
-        }); 
+        });
     },
     test_SMSWhiteSpaceRemoval: function(test) {
         var input = "5th\tand G Street\nSome Other\n Text";
@@ -285,7 +285,7 @@ exports.group = {
             test.ok(spy.called && spy.args[0][0] == "5th and G Street", "Test SMS Removal of multi-line input");
             lib.getStopsFromAddress.restore();
             test.done();
-        }); 
+        });
     },
 //Test the home page
     test_browserHome: function (test) {


### PR DESCRIPTION
This updates the now depreciated Turf version and uses the new version that is broken into modules. Only two of the modules are needed for us, which makes the app significantly smaller. Instead of using Turf.buffer, this now just uses Turf/distance to find stops around a point. It is 10 - 20 times faster.