### PR TITLE
Fix bug caused by known_location being an object rather than an array.

### DIFF
--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -323,7 +323,7 @@ function askWatson(req, res, next){
  */
 function addressResponder(req, res, next){
     const known_location = res.locals.known_location
-    const input = (known_location && known_location.length > 0) ? known_location[0].value : req.body.Body;
+    const input = known_location ? known_location.value : req.body.Body;
     res.locals.action = 'Address Lookup'
     return geocode.stops_near_location(input)
     .then((routeObject) => {


### PR DESCRIPTION
Small fix to a bug that's causing a small number of queries to return poor results.  `known_location` isn't an array it's an object.