### PR TITLE
prevent 404 errors from sending to Rollbar. Sends 404 instead

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,11 +108,10 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', routes);
 
-// catch 404 and forward to error handler
+// catch 404 for anything not handled in routes.
 app.use(function(req, res, next) {
-    const err = new Error('Not Found');
-    err.status = 404;
-    next(err);
+    res.status(404)
+    res.send("NOT FOUND")
 });
 
 // error handlers


### PR DESCRIPTION
Intercept unhandled routes and send 404 without calling Rollbar. This should only effect non-GET requests. GET requests are currently handled in routes.