### PR TITLE
Bt url

### DIFF
--- a/lib/bustracker.js
+++ b/lib/bustracker.js
@@ -34,13 +34,13 @@ const gtfs = require('./gtfs')
  * @returns {Promise<StopData>}
  */
 function getStopFromStopNumber(stopId) {
-    const busTrackerId = gtfs.stop_number_lookup[stopId];
-    if (!busTrackerId) {
+    const busTrackerURL = gtfs.stop_number_url[stopId];
+    if (!busTrackerURL) {
         const err = new Error("Stop numbers are on the bus stop sign (you can skip leading zeroes). If you can't find the stop number, send an address or intersection.")
         err.name = `I couldn't find stop number ${stopId}`
         return Promise.reject(err)
     }
-    return requestBusData(busTrackerId)
+    return requestBusData(busTrackerURL)
         .then(muniBusData => ({data: parseBusData(muniBusData.data, stopId), muniTime:muniBusData.asyncTime}))
         .catch((err) => Promise.reject(new Error('Sorry, Bustracker is down')))
 }
@@ -51,10 +51,10 @@ function getStopFromStopNumber(stopId) {
  * @param {number} busTrackerId
  * @returns {Promise<{data: string, asyncTime: number}>}
  */
-function requestBusData(busTrackerId) {
+function requestBusData(busTrackerURL) {
     return new Promise((resolve, reject) => {
         let asyncTime =  Date.now()
-        const request = http.get(config.MUNI_URL + busTrackerId, response => {
+        const request = http.get(busTrackerURL, response => {
             if (response.statusCode < 200 || response.statusCode > 299) {
                 logger.error(new MuniError(`Muni Server returned status code: ${response.statusCode}`))
                 reject(new Error('Failed to load bustracker, status code: ' + response.statusCode));

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,7 +11,6 @@ module.exports = {
     GEOCODE_URL_BASE: "https://maps.googleapis.com/maps/api/place/textsearch/json?",
 
     TIMEZONE: "America/Anchorage",
-    //MUNI_URL: process.env.MUNI_URL || "http://bustracker.muni.org/InfoPoint/departures.aspx?stopid=",
     LOG_DAYS_BACK: 5,
     MY_PHONE: process.env.MY_PHONE || "+19073122060",
     GOOGLE_ANALYTICS_ID: process.env.GOOGLE_ANALYTICS_ID || 'fake_google_an_key', // Code for Anchorage tracking Code for bus app = "UA-56999250-2"
@@ -32,4 +31,3 @@ module.exports = {
     WATSON_WORKPLACE_ID: process.env.WATSON_WORKPLACE_ID || 'fake_watson_workplace'
 
 }
-

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,7 +11,7 @@ module.exports = {
     GEOCODE_URL_BASE: "https://maps.googleapis.com/maps/api/place/textsearch/json?",
 
     TIMEZONE: "America/Anchorage",
-    MUNI_URL: process.env.MUNI_URL || "http://bustracker.muni.org/InfoPoint/departures.aspx?stopid=",
+    //MUNI_URL: process.env.MUNI_URL || "http://bustracker.muni.org/InfoPoint/departures.aspx?stopid=",
     LOG_DAYS_BACK: 5,
     MY_PHONE: process.env.MY_PHONE || "+19073122060",
     GOOGLE_ANALYTICS_ID: process.env.GOOGLE_ANALYTICS_ID || 'fake_google_an_key', // Code for Anchorage tracking Code for bus app = "UA-56999250-2"

--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -150,9 +150,9 @@ class Stops extends WatchedFile {
                 return makeGeoJSONPoint(point)
             })
         }
-        this.stop_lookup = {}
+        this.stop_url = {}
         data.forEach((point) => {
-            this.stop_lookup[parseInt(point.stop_id)] = parseInt(point.bt_id)
+            this.stop_url[parseInt(point.stop_id)] = point.stop_url
         })
     }
 }
@@ -163,7 +163,7 @@ function makeGeoJSONPoint(point){
         "properties": {
             "name": point.stop_name,
             "stop_id": point.stop_id,
-            "stop_code": point.bt_id
+            "stop_url": point.stop_url
         },
         "geometry": {
             type: "Point",
@@ -202,7 +202,7 @@ fs.ensureDir(raw_directory)
 module.exports = {
     get all_stops() { return all_stops.parsed_data },
     get exceptions() { return exceptions.parsed_data},
-    get stop_number_lookup() {return all_stops.stop_lookup },
+    get stop_number_url() {return all_stops.stop_url },
     serviceExceptions: serviceExceptions,
     getGTFSFile: getGTFSFile,
     GTFS_Check: GTFS_Check

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-4.7.3.tgz",
       "integrity": "sha1-tatIoJpkJwbWXDm5GUM9XSzFcbE=",
       "requires": {
-        "@turf/helpers": "4.7.3",
-        "@turf/invariant": "4.7.3"
+        "@turf/helpers": "^4.7.3",
+        "@turf/invariant": "^4.7.3"
       }
     },
     "@turf/helpers": {
@@ -23,12 +23,21 @@
       "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-4.7.3.tgz",
       "integrity": "sha1-U482fSPBE/yEnXDJpSS4Vjh0YB0="
     },
+    "JSONStream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+      "integrity": "sha1-cAyORxH+8c5CH2UL6tVSNbsh194=",
+      "requires": {
+        "jsonparse": "^1.1.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "accepts": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
       "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
       "requires": {
-        "mime-types": "2.1.16",
+        "mime-types": "~2.1.6",
         "negotiator": "0.5.3"
       },
       "dependencies": {
@@ -42,7 +51,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
           "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
           "requires": {
-            "mime-db": "1.29.0"
+            "mime-db": "~1.29.0"
           }
         }
       }
@@ -57,7 +66,7 @@
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -72,8 +81,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "align-text": {
@@ -81,9 +90,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -109,7 +118,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "asap": {
@@ -170,18 +179,13 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bignumber.js": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.1.1.tgz",
       "integrity": "sha1-GkFdmsAUwTJWrx/u2dGj5XF6jPc="
-    },
-    "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "bluebird": {
       "version": "3.5.0",
@@ -194,13 +198,13 @@
       "integrity": "sha1-QF1GX808zw6oo1rb8QVfbpgxa9E=",
       "requires": {
         "bytes": "1.0.0",
-        "depd": "1.0.1",
+        "depd": "~1.0.0",
         "iconv-lite": "0.4.6",
         "media-typer": "0.3.0",
-        "on-finished": "2.2.1",
+        "on-finished": "~2.2.0",
         "qs": "2.3.3",
         "raw-body": "1.3.2",
-        "type-is": "1.5.7"
+        "type-is": "~1.5.5"
       },
       "dependencies": {
         "on-finished": {
@@ -218,7 +222,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "brace-expansion": {
@@ -227,7 +231,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -247,7 +251,7 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
       "integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
       "requires": {
-        "is-array-buffer-x": "1.4.0"
+        "is-array-buffer-x": "^1.0.13"
       }
     },
     "build": {
@@ -256,16 +260,16 @@
       "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
       "dev": true,
       "requires": {
-        "cssmin": "0.3.2",
-        "jsmin": "1.0.1",
-        "jxLoader": "0.1.1",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "timespan": "2.3.0",
-        "uglify-js": "1.3.5",
-        "walker": "1.0.7",
-        "winston": "2.3.1",
-        "wrench": "1.3.9"
+        "cssmin": "0.3.x",
+        "jsmin": "1.x",
+        "jxLoader": "*",
+        "moo-server": "*",
+        "promised-io": "*",
+        "timespan": "2.x",
+        "uglify-js": "1.x",
+        "walker": "1.x",
+        "winston": "*",
+        "wrench": "1.3.x"
       },
       "dependencies": {
         "uglify-js": {
@@ -296,8 +300,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
@@ -306,9 +310,9 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
       }
     },
     "chalk": {
@@ -317,11 +321,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.2",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       },
       "dependencies": {
         "supports-color": {
@@ -337,7 +341,7 @@
       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
       "requires": {
-        "is-regex": "1.0.4"
+        "is-regex": "^1.0.3"
       }
     },
     "clean-css": {
@@ -345,8 +349,8 @@
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
       "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
       "requires": {
-        "commander": "2.8.1",
-        "source-map": "0.4.4"
+        "commander": "2.8.x",
+        "source-map": "0.4.x"
       },
       "dependencies": {
         "commander": {
@@ -354,7 +358,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         }
       }
@@ -370,8 +374,8 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       }
     },
@@ -383,7 +387,7 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true
     },
     "colors": {
@@ -396,7 +400,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -422,8 +426,8 @@
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.0.tgz",
       "integrity": "sha1-dWnKqKo/jVk11i4fqW+fcCzYHHk=",
       "requires": {
-        "acorn": "3.3.0",
-        "is-expression": "2.1.0"
+        "acorn": "^3.1.0",
+        "is-expression": "^2.0.1"
       }
     },
     "content-disposition": {
@@ -486,10 +490,10 @@
           "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.11.0",
-            "is-my-json-valid": "2.16.1",
-            "pinkie-promise": "2.0.1"
+            "chalk": "^1.1.1",
+            "commander": "^2.9.0",
+            "is-my-json-valid": "^2.12.4",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "js-yaml": {
@@ -498,8 +502,8 @@
           "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
           }
         },
         "mime-db": {
@@ -514,7 +518,7 @@
           "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
           "dev": true,
           "requires": {
-            "mime-db": "1.29.0"
+            "mime-db": "~1.29.0"
           }
         },
         "minimist": {
@@ -535,26 +539,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.16",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.3.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1",
+            "uuid": "^3.0.0"
           }
         },
         "tunnel-agent": {
@@ -575,7 +579,7 @@
       "resolved": "https://registry.npmjs.org/cron/-/cron-1.3.0.tgz",
       "integrity": "sha512-K/SF7JlgMmNjcThWxkKvsHhey2EDB4CeOEWJ9aXWj3fbQJppsvTPIeyLdHfNq5IbbsMUUjRW1nr5dSO95f2E4w==",
       "requires": {
-        "moment-timezone": "0.5.13"
+        "moment-timezone": "^0.5.x"
       }
     },
     "cross-spawn": {
@@ -584,8 +588,8 @@
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
       },
       "dependencies": {
         "lru-cache": {
@@ -594,8 +598,8 @@
           "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         }
       }
@@ -605,7 +609,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       }
     },
     "cssmin": {
@@ -624,7 +628,7 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.0.4.tgz",
       "integrity": "sha1-vBi6ua1M7zGV/SV5gLWLR5xC0+U=",
       "requires": {
-        "lodash.get": "4.4.2"
+        "lodash.get": "^4.0.0"
       }
     },
     "cycle": {
@@ -637,7 +641,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -661,7 +665,7 @@
       "integrity": "sha1-T1A2+9ZYH8yXI3rDlUokS5U2wto=",
       "optional": true,
       "requires": {
-        "find": "0.2.7"
+        "find": "^0.2.4"
       }
     },
     "decamelize": {
@@ -740,7 +744,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -748,8 +752,8 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
       "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
       "requires": {
-        "base64url": "2.0.0",
-        "safe-buffer": "5.1.1"
+        "base64url": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -760,7 +764,7 @@
     "emoji-regex": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-      "integrity": "sha1-m66pKbFVVlwR6kHGYm6qZc75ksI="
+      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ=="
     },
     "escape-html": {
       "version": "1.0.1",
@@ -798,30 +802,30 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.11.2.tgz",
       "integrity": "sha1-jfPVqayEhYXwCgd3YBgj+uzTsUg=",
       "requires": {
-        "accepts": "1.2.13",
+        "accepts": "~1.2.3",
         "content-disposition": "0.5.0",
         "cookie": "0.1.2",
         "cookie-signature": "1.0.5",
-        "debug": "2.1.3",
-        "depd": "1.0.1",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
         "escape-html": "1.0.1",
-        "etag": "1.5.1",
+        "etag": "~1.5.1",
         "finalhandler": "0.3.3",
         "fresh": "0.2.4",
         "media-typer": "0.3.0",
         "merge-descriptors": "0.0.2",
-        "methods": "1.1.2",
-        "on-finished": "2.2.1",
-        "parseurl": "1.3.1",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
         "path-to-regexp": "0.1.3",
-        "proxy-addr": "1.0.10",
+        "proxy-addr": "~1.0.6",
         "qs": "2.3.3",
-        "range-parser": "1.0.3",
+        "range-parser": "~1.0.2",
         "send": "0.11.1",
-        "serve-static": "1.8.1",
-        "type-is": "1.5.7",
+        "serve-static": "~1.8.1",
+        "type-is": "~1.5.6",
         "utils-merge": "1.0.0",
-        "vary": "1.0.1"
+        "vary": "~1.0.0"
       },
       "dependencies": {
         "cookie": {
@@ -864,9 +868,9 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz",
       "integrity": "sha1-saCaoeamB7NUFmmwm8tyf0YM1CY=",
       "requires": {
-        "debug": "2.1.3",
+        "debug": "~2.1.1",
         "escape-html": "1.0.1",
-        "on-finished": "2.2.1"
+        "on-finished": "~2.2.0"
       },
       "dependencies": {
         "on-finished": {
@@ -885,7 +889,7 @@
       "integrity": "sha1-evvQD48IxbYi+Xzab3FBc9VHuz8=",
       "optional": true,
       "requires": {
-        "traverse-chain": "0.1.0"
+        "traverse-chain": "~0.1.0"
       }
     },
     "for-in": {
@@ -898,7 +902,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreground-child": {
@@ -907,8 +911,8 @@
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
-        "cross-spawn": "4.0.2",
-        "signal-exit": "3.0.2"
+        "cross-spawn": "^4",
+        "signal-exit": "^3.0.0"
       }
     },
     "forever-agent": {
@@ -921,9 +925,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.16"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       },
       "dependencies": {
         "mime-db": {
@@ -936,7 +940,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
           "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
           "requires": {
-            "mime-db": "1.29.0"
+            "mime-db": "~1.29.0"
           }
         }
       }
@@ -947,7 +951,7 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "samsam": "1.x"
       }
     },
     "formidable": {
@@ -971,9 +975,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -999,7 +1003,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "getpass": {
@@ -1007,7 +1011,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -1023,12 +1027,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -1057,8 +1061,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
       "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
+        "ajv": "^4.9.1",
+        "har-schema": "^1.0.5"
       }
     },
     "has": {
@@ -1066,7 +1070,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -1075,7 +1079,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -1094,7 +1098,7 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.0.tgz",
       "integrity": "sha1-Sde83oXCQJvjisMn4+EZpFFlfHs=",
       "requires": {
-        "has-symbol-support-x": "1.4.0"
+        "has-symbol-support-x": "^1.4.0"
       }
     },
     "hashwords": {
@@ -1107,10 +1111,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "he": {
@@ -1134,9 +1138,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "httperror": {
@@ -1158,8 +1162,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1178,9 +1182,9 @@
       "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.4.0.tgz",
       "integrity": "sha1-xGWGq0Vv3wafqf3ydganTHqHGe8=",
       "requires": {
-        "has-to-string-tag-x": "1.4.0",
-        "is-object-like-x": "1.5.0",
-        "to-string-tag-x": "1.4.0"
+        "has-to-string-tag-x": "^1.4.0",
+        "is-object-like-x": "^1.5.0",
+        "to-string-tag-x": "^1.4.0"
       }
     },
     "is-buffer": {
@@ -1193,8 +1197,8 @@
       "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-2.1.0.tgz",
       "integrity": "sha1-kb6dR968/vB3l36XIr5tz7RGXvA=",
       "requires": {
-        "acorn": "3.3.0",
-        "object-assign": "4.1.1"
+        "acorn": "~3.3.0",
+        "object-assign": "^4.0.1"
       }
     },
     "is-extendable": {
@@ -1207,11 +1211,11 @@
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.1.0.tgz",
       "integrity": "sha1-fxoONue0YBPkcYgH8KIMyHRLY6k=",
       "requires": {
-        "has-to-string-tag-x": "1.4.0",
-        "is-primitive": "2.0.0",
-        "normalize-space-x": "1.3.2",
-        "replace-comments-x": "1.0.1",
-        "to-string-tag-x": "1.4.0"
+        "has-to-string-tag-x": "^1.4.0",
+        "is-primitive": "^2.0.0",
+        "normalize-space-x": "^1.3.2",
+        "replace-comments-x": "^1.0.1",
+        "to-string-tag-x": "^1.4.0"
       }
     },
     "is-my-json-valid": {
@@ -1220,10 +1224,10 @@
       "integrity": "sha1-WoRnd+LCYg0eaRBOXToDsfYIjxE=",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-object-like-x": {
@@ -1231,8 +1235,8 @@
       "resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.5.0.tgz",
       "integrity": "sha1-A20fVSD2AWeT2eSSdh1w2EUvNvA=",
       "requires": {
-        "is-function-x": "3.1.0",
-        "is-primitive": "2.0.0"
+        "is-function-x": "^3.1.0",
+        "is-primitive": "^2.0.0"
       }
     },
     "is-primitive": {
@@ -1251,7 +1255,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-string": {
@@ -1298,20 +1302,15 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
-    "items": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
-    },
     "joi": {
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
       "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
       "requires": {
-        "hoek": "2.16.3",
-        "isemail": "1.2.0",
-        "moment": "2.18.1",
-        "topo": "1.1.0"
+        "hoek": "2.x.x",
+        "isemail": "1.x.x",
+        "moment": "2.x.x",
+        "topo": "1.x.x"
       }
     },
     "js-stringify": {
@@ -1325,8 +1324,8 @@
       "integrity": "sha1-CHdc69/dNZIJ8NKs04PI+GppBKA=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -1354,7 +1353,7 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.1.4.tgz",
       "integrity": "sha1-tdQLipAJ6S8Vf3wHnbCXABgw4B4=",
       "requires": {
-        "bignumber.js": "1.1.1"
+        "bignumber.js": "~1.1.1"
       }
     },
     "json-schema": {
@@ -1367,7 +1366,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -1380,7 +1379,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -1399,25 +1398,16 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
-      "integrity": "sha1-cAyORxH+8c5CH2UL6tVSNbsh194=",
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "jsonwebtoken": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
       "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
       "requires": {
-        "joi": "6.10.1",
-        "jws": "3.1.4",
-        "lodash.once": "4.1.1",
-        "ms": "2.0.0",
-        "xtend": "4.0.1"
+        "joi": "^6.10.1",
+        "jws": "^3.1.4",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.0.0",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "ms": {
@@ -1450,8 +1440,8 @@
       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
       "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
       "requires": {
-        "is-promise": "2.1.0",
-        "promise": "7.3.1"
+        "is-promise": "^2.0.0",
+        "promise": "^7.0.1"
       },
       "dependencies": {
         "is-promise": {
@@ -1475,7 +1465,7 @@
         "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.9",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "jws": {
@@ -1483,9 +1473,9 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
       "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
       "requires": {
-        "base64url": "2.0.0",
-        "jwa": "1.1.5",
-        "safe-buffer": "5.1.1"
+        "base64url": "^2.0.0",
+        "jwa": "^1.1.4",
+        "safe-buffer": "^5.0.1"
       }
     },
     "jxLoader": {
@@ -1494,10 +1484,10 @@
       "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
       "dev": true,
       "requires": {
-        "js-yaml": "0.3.7",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "walker": "1.0.7"
+        "js-yaml": "0.3.x",
+        "moo-server": "1.3.x",
+        "promised-io": "*",
+        "walker": "1.x"
       },
       "dependencies": {
         "js-yaml": {
@@ -1513,7 +1503,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -1569,10 +1559,10 @@
       "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-0.16.2.tgz",
       "integrity": "sha1-oql262bsV3lykZcPPIfNthEm+jo=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "is-promise": "2.1.0",
-        "lodash": "4.17.4",
-        "steno": "0.4.4"
+        "graceful-fs": "^4.1.3",
+        "is-promise": "^2.1.0",
+        "lodash": "4",
+        "steno": "^0.4.1"
       },
       "dependencies": {
         "is-promise": {
@@ -1593,7 +1583,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "media-typer": {
@@ -1626,7 +1616,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
       "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
       "requires": {
-        "mime-db": "1.12.0"
+        "mime-db": "~1.12.0"
       }
     },
     "minimatch": {
@@ -1635,7 +1625,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1710,7 +1700,7 @@
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
       "integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A=",
       "requires": {
-        "moment": "2.18.1"
+        "moment": ">= 2.9.0"
       }
     },
     "moo-server": {
@@ -1752,11 +1742,11 @@
       "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
       "dev": true,
       "requires": {
-        "formatio": "1.2.0",
-        "just-extend": "1.1.27",
-        "lolex": "1.6.0",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "formatio": "^1.2.0",
+        "just-extend": "^1.1.26",
+        "lolex": "^1.6.0",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       },
       "dependencies": {
         "isarray": {
@@ -1788,15 +1778,15 @@
       "integrity": "sha512-DuKF+1W/FnMO6MXIGgCIWcM95bETjBbmFdR4v7dAj1zH9a9XhOjAa//PuWh98XIXxcZt7wdiv0JlO0AA0e2kqQ==",
       "dev": true,
       "requires": {
-        "chai": "3.5.0",
-        "debug": "2.6.9",
-        "deep-equal": "1.0.1",
-        "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
+        "chai": ">=1.9.2 <4.0.0",
+        "debug": "^2.2.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "~4.17.2",
+        "mkdirp": "^0.5.0",
         "propagate": "0.4.0",
-        "qs": "6.5.1",
-        "semver": "5.5.0"
+        "qs": "^6.5.1",
+        "semver": "^5.3.0"
       },
       "dependencies": {
         "debug": {
@@ -1822,31 +1812,22 @@
         }
       }
     },
-    "node-expat": {
-      "version": "2.3.16",
-      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.3.16.tgz",
-      "integrity": "sha512-e3HyQI0lk5CXyYQ4RsDYGiWdY5LJxNMlNCzo4/gwqY8lhYIeTf5VwGirGDa1EPrcZROmOR37wHuFVnoHmOWnOw==",
-      "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.7.0"
-      }
-    },
     "node-mocks-http": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.6.6.tgz",
       "integrity": "sha1-D97vhmzBIqgAUbvYmodtPEzSHhM=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.4",
-        "depd": "1.1.2",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "mime": "1.6.0",
-        "net": "1.0.2",
-        "parseurl": "1.3.1",
-        "range-parser": "1.2.0",
-        "type-is": "1.6.15"
+        "accepts": "^1.3.3",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "net": "^1.0.2",
+        "parseurl": "^1.3.1",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.14"
       },
       "dependencies": {
         "accepts": {
@@ -1855,7 +1836,7 @@
           "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
           "dev": true,
           "requires": {
-            "mime-types": "2.1.17",
+            "mime-types": "~2.1.16",
             "negotiator": "0.6.1"
           }
         },
@@ -1895,7 +1876,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "~1.30.0"
           }
         },
         "negotiator": {
@@ -1917,7 +1898,7 @@
           "dev": true,
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.1.17"
+            "mime-types": "~2.1.15"
           }
         }
       }
@@ -1928,7 +1909,7 @@
       "integrity": "sha1-C2MjaAB9lGUczwoYmZgHmC8HOGY=",
       "dev": true,
       "requires": {
-        "tap": "7.1.2"
+        "tap": "^7.0.0"
       }
     },
     "nodeunit-httpclient": {
@@ -1953,8 +1934,8 @@
       "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-1.3.2.tgz",
       "integrity": "sha1-9OOYSupsueJs9YQiQFGtDxgndJg=",
       "requires": {
-        "trim-x": "1.0.2",
-        "white-space-x": "2.0.2"
+        "trim-x": "^1.0.2",
+        "white-space-x": "^2.0.2"
       }
     },
     "nyc": {
@@ -1963,33 +1944,33 @@
       "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
       "dev": true,
       "requires": {
-        "archy": "1.0.0",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.5.1",
-        "debug-log": "1.0.1",
-        "default-require-extensions": "1.0.0",
-        "find-cache-dir": "0.1.1",
-        "find-up": "2.1.0",
-        "foreground-child": "1.5.6",
-        "glob": "7.1.2",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "1.9.1",
-        "istanbul-lib-report": "1.1.2",
-        "istanbul-lib-source-maps": "1.2.2",
-        "istanbul-reports": "1.1.3",
-        "md5-hex": "1.3.0",
-        "merge-source-map": "1.0.4",
-        "micromatch": "2.3.11",
-        "mkdirp": "0.5.1",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.6.2",
-        "signal-exit": "3.0.2",
-        "spawn-wrap": "1.4.2",
-        "test-exclude": "4.1.1",
-        "yargs": "10.0.3",
-        "yargs-parser": "8.0.0"
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.3.0",
+        "debug-log": "^1.0.1",
+        "default-require-extensions": "^1.0.0",
+        "find-cache-dir": "^0.1.1",
+        "find-up": "^2.1.0",
+        "foreground-child": "^1.5.3",
+        "glob": "^7.0.6",
+        "istanbul-lib-coverage": "^1.1.1",
+        "istanbul-lib-hook": "^1.1.0",
+        "istanbul-lib-instrument": "^1.9.1",
+        "istanbul-lib-report": "^1.1.2",
+        "istanbul-lib-source-maps": "^1.2.2",
+        "istanbul-reports": "^1.1.3",
+        "md5-hex": "^1.2.0",
+        "merge-source-map": "^1.0.2",
+        "micromatch": "^2.3.11",
+        "mkdirp": "^0.5.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.5.4",
+        "signal-exit": "^3.0.1",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^4.1.1",
+        "yargs": "^10.0.3",
+        "yargs-parser": "^8.0.0"
       },
       "dependencies": {
         "align-text": {
@@ -1997,9 +1978,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
           }
         },
         "amdefine": {
@@ -2022,7 +2003,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "default-require-extensions": "1.0.0"
+            "default-require-extensions": "^1.0.0"
           }
         },
         "archy": {
@@ -2035,7 +2016,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "arr-flatten": {
@@ -2063,9 +2044,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-generator": {
@@ -2073,14 +2054,14 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.6",
+            "trim-right": "^1.0.1"
           }
         },
         "babel-messages": {
@@ -2088,7 +2069,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-runtime": {
@@ -2096,8 +2077,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "2.5.3",
-            "regenerator-runtime": "0.11.1"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -2105,11 +2086,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -2117,15 +2098,15 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -2133,10 +2114,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babylon": {
@@ -2154,7 +2135,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2163,9 +2144,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "builtin-modules": {
@@ -2178,9 +2159,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "write-file-atomic": "1.3.4"
+            "md5-hex": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "write-file-atomic": "^1.1.4"
           }
         },
         "camelcase": {
@@ -2195,8 +2176,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
           }
         },
         "chalk": {
@@ -2204,11 +2185,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cliui": {
@@ -2217,8 +2198,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           },
           "dependencies": {
@@ -2260,8 +2241,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
-            "which": "1.3.0"
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
           }
         },
         "debug": {
@@ -2287,7 +2268,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-bom": "2.0.0"
+            "strip-bom": "^2.0.0"
           }
         },
         "detect-indent": {
@@ -2295,7 +2276,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "error-ex": {
@@ -2303,7 +2284,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "escape-string-regexp": {
@@ -2321,13 +2302,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           },
           "dependencies": {
             "cross-spawn": {
@@ -2335,9 +2316,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "4.1.1",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
               }
             }
           }
@@ -2347,7 +2328,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -2355,7 +2336,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "^2.1.0"
           }
         },
         "extglob": {
@@ -2363,7 +2344,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "filename-regex": {
@@ -2376,11 +2357,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "find-cache-dir": {
@@ -2388,9 +2369,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           }
         },
         "find-up": {
@@ -2398,7 +2379,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         },
         "for-in": {
@@ -2411,7 +2392,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         },
         "foreground-child": {
@@ -2419,8 +2400,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
           }
         },
         "fs.realpath": {
@@ -2443,12 +2424,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-base": {
@@ -2456,8 +2437,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "glob-parent": {
@@ -2465,7 +2446,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "globals": {
@@ -2483,10 +2464,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
           },
           "dependencies": {
             "source-map": {
@@ -2494,7 +2475,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             }
           }
@@ -2504,7 +2485,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -2527,8 +2508,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -2541,7 +2522,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "invert-kv": {
@@ -2564,7 +2545,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-dotfile": {
@@ -2577,7 +2558,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-primitive": "2.0.0"
+            "is-primitive": "^2.0.0"
           }
         },
         "is-extendable": {
@@ -2595,7 +2576,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -2603,7 +2584,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-glob": {
@@ -2611,7 +2592,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "is-number": {
@@ -2619,7 +2600,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-posix-bracket": {
@@ -2670,7 +2651,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "0.4.0"
+            "append-transform": "^0.4.0"
           }
         },
         "istanbul-lib-instrument": {
@@ -2678,13 +2659,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-generator": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "istanbul-lib-coverage": "1.1.1",
-            "semver": "5.4.1"
+            "babel-generator": "^6.18.0",
+            "babel-template": "^6.16.0",
+            "babel-traverse": "^6.18.0",
+            "babel-types": "^6.18.0",
+            "babylon": "^6.18.0",
+            "istanbul-lib-coverage": "^1.1.1",
+            "semver": "^5.3.0"
           }
         },
         "istanbul-lib-report": {
@@ -2692,10 +2673,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "1.1.1",
-            "mkdirp": "0.5.1",
-            "path-parse": "1.0.5",
-            "supports-color": "3.2.3"
+            "istanbul-lib-coverage": "^1.1.1",
+            "mkdirp": "^0.5.1",
+            "path-parse": "^1.0.5",
+            "supports-color": "^3.1.2"
           },
           "dependencies": {
             "supports-color": {
@@ -2703,7 +2684,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "has-flag": "1.0.0"
+                "has-flag": "^1.0.0"
               }
             }
           }
@@ -2713,11 +2694,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "3.1.0",
-            "istanbul-lib-coverage": "1.1.1",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7"
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^1.1.1",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.6.1",
+            "source-map": "^0.5.3"
           },
           "dependencies": {
             "debug": {
@@ -2735,7 +2716,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "handlebars": "4.0.11"
+            "handlebars": "^4.0.3"
           }
         },
         "js-tokens": {
@@ -2753,7 +2734,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "lazy-cache": {
@@ -2767,7 +2748,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "load-json-file": {
@@ -2775,11 +2756,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "locate-path": {
@@ -2787,8 +2768,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -2813,7 +2794,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "lru-cache": {
@@ -2821,8 +2802,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "md5-hex": {
@@ -2830,7 +2811,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           }
         },
         "md5-o-matic": {
@@ -2843,7 +2824,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "merge-source-map": {
@@ -2851,7 +2832,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         },
         "micromatch": {
@@ -2859,19 +2840,19 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         },
         "mimic-fn": {
@@ -2884,7 +2865,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -2910,10 +2891,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "normalize-path": {
@@ -2921,7 +2902,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "npm-run-path": {
@@ -2929,7 +2910,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-key": "2.0.1"
+            "path-key": "^2.0.0"
           }
         },
         "number-is-nan": {
@@ -2947,8 +2928,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
           }
         },
         "once": {
@@ -2956,7 +2937,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "optimist": {
@@ -2964,8 +2945,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           }
         },
         "os-homedir": {
@@ -2978,9 +2959,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "p-finally": {
@@ -2998,7 +2979,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "p-limit": "1.1.0"
+            "p-limit": "^1.1.0"
           }
         },
         "parse-glob": {
@@ -3006,10 +2987,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
           }
         },
         "parse-json": {
@@ -3017,7 +2998,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -3025,7 +3006,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -3048,9 +3029,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -3068,7 +3049,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -3076,7 +3057,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -3084,8 +3065,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -3105,8 +3086,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -3114,7 +3095,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -3122,7 +3103,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -3132,7 +3113,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -3142,9 +3123,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -3152,8 +3133,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -3161,8 +3142,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             }
           }
@@ -3177,7 +3158,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-equal-shallow": "0.1.3"
+            "is-equal-shallow": "^0.1.3"
           }
         },
         "remove-trailing-separator": {
@@ -3200,7 +3181,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "require-directory": {
@@ -3224,7 +3205,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "0.1.4"
+            "align-text": "^0.1.1"
           }
         },
         "rimraf": {
@@ -3232,7 +3213,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "semver": {
@@ -3250,7 +3231,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -3278,12 +3259,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "1.5.6",
-            "mkdirp": "0.5.1",
-            "os-homedir": "1.0.2",
-            "rimraf": "2.6.2",
-            "signal-exit": "3.0.2",
-            "which": "1.3.0"
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
           }
         },
         "spdx-correct": {
@@ -3291,7 +3272,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-license-ids": "1.2.2"
+            "spdx-license-ids": "^1.0.2"
           }
         },
         "spdx-expression-parse": {
@@ -3309,8 +3290,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -3328,7 +3309,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -3338,7 +3319,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -3346,7 +3327,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-eof": {
@@ -3364,11 +3345,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "2.3.11",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
+            "arrify": "^1.0.1",
+            "micromatch": "^2.3.11",
+            "object-assign": "^4.1.0",
+            "read-pkg-up": "^1.0.1",
+            "require-main-filename": "^1.0.1"
           }
         },
         "to-fast-properties": {
@@ -3387,9 +3368,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "yargs": {
@@ -3398,9 +3379,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
               }
             }
@@ -3417,8 +3398,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.4"
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
           }
         },
         "which": {
@@ -3426,7 +3407,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -3450,8 +3431,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "string-width": {
@@ -3459,9 +3440,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -3476,9 +3457,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         },
         "y18n": {
@@ -3496,18 +3477,18 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "8.0.0"
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^8.0.0"
           },
           "dependencies": {
             "cliui": {
@@ -3515,9 +3496,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
               },
               "dependencies": {
                 "string-width": {
@@ -3525,9 +3506,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
                   }
                 }
               }
@@ -3539,7 +3520,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           },
           "dependencies": {
             "camelcase": {
@@ -3566,8 +3547,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.pick": {
@@ -3575,7 +3556,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
       "integrity": "sha1-tTkr7peC2m2ft9avr1OXefEjTCs=",
       "requires": {
-        "isobject": "2.1.0"
+        "isobject": "^2.1.0"
       }
     },
     "on-finished": {
@@ -3604,7 +3585,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "only-shallow": {
@@ -3663,7 +3644,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pop-iterate": {
@@ -3682,7 +3663,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "promised-io": {
@@ -3702,7 +3683,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
       "integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
       "requires": {
-        "forwarded": "0.1.0",
+        "forwarded": "~0.1.0",
         "ipaddr.js": "1.0.5"
       }
     },
@@ -3717,14 +3698,14 @@
       "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.0-rc.4.tgz",
       "integrity": "sha512-SL7xovj6E2Loq9N0UgV6ynjMLW4urTFY/L/Fprhvz13Xc5vjzkjZjI1QHKq31200+6PSD8PyU6MqrtCTJj6/XA==",
       "requires": {
-        "pug-code-gen": "2.0.0",
-        "pug-filters": "2.1.5",
-        "pug-lexer": "3.1.0",
-        "pug-linker": "3.0.3",
-        "pug-load": "2.0.9",
-        "pug-parser": "4.0.0",
-        "pug-runtime": "2.0.3",
-        "pug-strip-comments": "1.0.2"
+        "pug-code-gen": "^2.0.0",
+        "pug-filters": "^2.1.5",
+        "pug-lexer": "^3.1.0",
+        "pug-linker": "^3.0.3",
+        "pug-load": "^2.0.9",
+        "pug-parser": "^4.0.0",
+        "pug-runtime": "^2.0.3",
+        "pug-strip-comments": "^1.0.2"
       }
     },
     "pug-attrs": {
@@ -3732,9 +3713,9 @@
       "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.2.tgz",
       "integrity": "sha1-i+KyIlVo/6ddG4Zpgr/59BEa/8s=",
       "requires": {
-        "constantinople": "3.1.0",
-        "js-stringify": "1.0.2",
-        "pug-runtime": "2.0.3"
+        "constantinople": "^3.0.1",
+        "js-stringify": "^1.0.1",
+        "pug-runtime": "^2.0.3"
       }
     },
     "pug-code-gen": {
@@ -3742,14 +3723,14 @@
       "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.0.tgz",
       "integrity": "sha512-E4oiJT+Jn5tyEIloj8dIJQognbiNNp0i0cAJmYtQTFS0soJ917nlIuFtqVss3IXMEyQKUew3F4gIkBpn18KbVg==",
       "requires": {
-        "constantinople": "3.1.0",
-        "doctypes": "1.1.0",
-        "js-stringify": "1.0.2",
-        "pug-attrs": "2.0.2",
-        "pug-error": "1.3.2",
-        "pug-runtime": "2.0.3",
-        "void-elements": "2.0.1",
-        "with": "5.1.1"
+        "constantinople": "^3.0.1",
+        "doctypes": "^1.1.0",
+        "js-stringify": "^1.0.1",
+        "pug-attrs": "^2.0.2",
+        "pug-error": "^1.3.2",
+        "pug-runtime": "^2.0.3",
+        "void-elements": "^2.0.1",
+        "with": "^5.0.0"
       }
     },
     "pug-error": {
@@ -3762,13 +3743,13 @@
       "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-2.1.5.tgz",
       "integrity": "sha512-xkw71KtrC4sxleKiq+cUlQzsiLn8pM5+vCgkChW2E6oNOzaqTSIBKIQ5cl4oheuDzvJYCTSYzRaVinMUrV4YLQ==",
       "requires": {
-        "clean-css": "3.4.28",
-        "constantinople": "3.1.0",
+        "clean-css": "^3.3.0",
+        "constantinople": "^3.0.1",
         "jstransformer": "1.0.0",
-        "pug-error": "1.3.2",
-        "pug-walk": "1.1.5",
-        "resolve": "1.5.0",
-        "uglify-js": "2.8.29"
+        "pug-error": "^1.3.2",
+        "pug-walk": "^1.1.5",
+        "resolve": "^1.1.6",
+        "uglify-js": "^2.6.1"
       }
     },
     "pug-lexer": {
@@ -3776,9 +3757,9 @@
       "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-3.1.0.tgz",
       "integrity": "sha1-/QhzdtSmdbT1n4/vQiiDQ06VgaI=",
       "requires": {
-        "character-parser": "2.2.0",
-        "is-expression": "3.0.0",
-        "pug-error": "1.3.2"
+        "character-parser": "^2.1.1",
+        "is-expression": "^3.0.0",
+        "pug-error": "^1.3.2"
       },
       "dependencies": {
         "acorn": {
@@ -3791,8 +3772,8 @@
           "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
           "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
           "requires": {
-            "acorn": "4.0.13",
-            "object-assign": "4.1.1"
+            "acorn": "~4.0.2",
+            "object-assign": "^4.0.1"
           }
         }
       }
@@ -3802,8 +3783,8 @@
       "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.3.tgz",
       "integrity": "sha512-DCKczglCXOzJ1lr4xUj/lVHYvS+lGmR2+KTCjZjtIpdwaN7lNOoX2SW6KFX5X4ElvW+6ThwB+acSUg08UJFN5A==",
       "requires": {
-        "pug-error": "1.3.2",
-        "pug-walk": "1.1.5"
+        "pug-error": "^1.3.2",
+        "pug-walk": "^1.1.5"
       }
     },
     "pug-load": {
@@ -3811,8 +3792,8 @@
       "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.9.tgz",
       "integrity": "sha512-BDdZOCru4mg+1MiZwRQZh25+NTRo/R6/qArrdWIf308rHtWA5N9kpoUskRe4H6FslaQujC+DigH9LqlBA4gf6Q==",
       "requires": {
-        "object-assign": "4.1.1",
-        "pug-walk": "1.1.5"
+        "object-assign": "^4.1.0",
+        "pug-walk": "^1.1.5"
       }
     },
     "pug-parser": {
@@ -3820,7 +3801,7 @@
       "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-4.0.0.tgz",
       "integrity": "sha512-ocEUFPdLG9awwFj0sqi1uiZLNvfoodCMULZzkRqILryIWc/UUlDlxqrKhKjAIIGPX/1SNsvxy63+ayEGocGhQg==",
       "requires": {
-        "pug-error": "1.3.2",
+        "pug-error": "^1.3.2",
         "token-stream": "0.0.1"
       }
     },
@@ -3834,7 +3815,7 @@
       "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.2.tgz",
       "integrity": "sha1-0xOvoBvMN0mA4TmeI+vy65vchRM=",
       "requires": {
-        "pug-error": "1.3.2"
+        "pug-error": "^1.3.2"
       }
     },
     "pug-walk": {
@@ -3877,13 +3858,13 @@
       "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "repeat-string": {
@@ -3896,7 +3877,7 @@
       "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-1.0.1.tgz",
       "integrity": "sha1-+8ZUzM2O9qT1F3tqN6crE6VmKAk=",
       "requires": {
-        "is-string": "1.0.4"
+        "is-string": "^1.0.4"
       }
     },
     "request": {
@@ -3904,28 +3885,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.16",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.6.0",
+        "aws4": "^1.2.1",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.1.1",
+        "har-validator": "~4.2.1",
+        "hawk": "~3.1.3",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "oauth-sign": "~0.8.1",
+        "performance-now": "^0.2.0",
+        "qs": "~6.4.0",
+        "safe-buffer": "^5.0.1",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.3.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.0.0"
       },
       "dependencies": {
         "mime-db": {
@@ -3938,7 +3919,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
           "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
           "requires": {
-            "mime-db": "1.29.0"
+            "mime-db": "~1.29.0"
           }
         },
         "qs": {
@@ -3958,7 +3939,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "right-align": {
@@ -3966,7 +3947,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rollbar": {
@@ -3974,13 +3955,13 @@
       "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-0.6.6.tgz",
       "integrity": "sha1-hjDP9K+WdmfQayJ/JDY16obcxbo=",
       "requires": {
-        "async": "1.2.1",
+        "async": "~1.2.1",
         "debug": "2.2.0",
-        "decache": "3.1.0",
-        "json-stringify-safe": "5.0.1",
-        "lru-cache": "2.2.4",
-        "request-ip": "1.2.3",
-        "uuid": "3.0.1"
+        "decache": "^3.0.5",
+        "json-stringify-safe": "~5.0.0",
+        "lru-cache": "~2.2.1",
+        "request-ip": "~1.2.3",
+        "uuid": "~3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -4013,7 +3994,7 @@
       "resolved": "https://registry.npmjs.org/run-middleware/-/run-middleware-0.6.6.tgz",
       "integrity": "sha1-E0SBO+aadAEFtIfbC9X6PQoDakI=",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "lodash": {
@@ -4050,16 +4031,16 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.11.1.tgz",
       "integrity": "sha1-G+q/1C+eJwn5kCivMHisErRwktU=",
       "requires": {
-        "debug": "2.1.3",
-        "depd": "1.0.1",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
         "destroy": "1.0.3",
         "escape-html": "1.0.1",
-        "etag": "1.5.1",
+        "etag": "~1.5.1",
         "fresh": "0.2.4",
         "mime": "1.2.11",
         "ms": "0.7.0",
-        "on-finished": "2.2.1",
-        "range-parser": "1.0.3"
+        "on-finished": "~2.2.0",
+        "range-parser": "~1.0.2"
       },
       "dependencies": {
         "on-finished": {
@@ -4077,10 +4058,10 @@
       "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.2.1.tgz",
       "integrity": "sha1-2XuswVD2b+DlzEx4qEuhW65aWEo=",
       "requires": {
-        "etag": "1.6.0",
+        "etag": "~1.6.0",
         "fresh": "0.2.4",
         "ms": "0.7.1",
-        "parseurl": "1.3.1"
+        "parseurl": "~1.3.0"
       },
       "dependencies": {
         "etag": {
@@ -4104,7 +4085,7 @@
       "integrity": "sha1-CPq9OZmfBQ/DEUQ/RtWIinfs/Hw=",
       "requires": {
         "escape-html": "1.0.1",
-        "parseurl": "1.3.1",
+        "parseurl": "~1.3.0",
         "send": "0.11.1",
         "utils-merge": "1.0.0"
       }
@@ -4121,17 +4102,17 @@
       "integrity": "sha512-/flfGfIxIRXSvZBHJzIf3iAyGYkmMQq6SQjA0cx9SOuVuq+4ZPPO4LJtH1Ce0Lznax1KSG1U6Dad85wIcSW19w==",
       "dev": true,
       "requires": {
-        "build": "0.1.4",
-        "diff": "3.4.0",
+        "build": "^0.1.4",
+        "diff": "^3.1.0",
         "formatio": "1.2.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.3.1",
-        "native-promise-only": "0.8.1",
-        "nise": "1.2.0",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.3.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.1.2",
+        "native-promise-only": "^0.8.1",
+        "nise": "^1.0.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
         "text-encoding": "0.6.4",
-        "type-detect": "4.0.7"
+        "type-detect": "^4.0.0"
       },
       "dependencies": {
         "diff": {
@@ -4168,7 +4149,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "solr-client": {
@@ -4176,12 +4157,12 @@
       "resolved": "https://registry.npmjs.org/solr-client/-/solr-client-0.7.0.tgz",
       "integrity": "sha1-uA/Mpsh3aD1XGLdaF3Jk8SIHt7g=",
       "requires": {
-        "bluebird": "3.5.0",
-        "duplexer": "0.1.1",
-        "httperror": "0.2.3",
-        "json-bigint": "0.1.4",
-        "JSONStream": "1.0.7",
-        "request": "2.81.0"
+        "JSONStream": "~1.0.6",
+        "bluebird": "^3.5.0",
+        "duplexer": "~0.1.1",
+        "httperror": "~0.2.3",
+        "json-bigint": "~0.1.4",
+        "request": "~2.81.0"
       }
     },
     "source-map": {
@@ -4189,7 +4170,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "sprintf-js": {
@@ -4203,14 +4184,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -4236,7 +4217,7 @@
       "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
       "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.3"
       }
     },
     "string": {
@@ -4250,7 +4231,7 @@
       "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -4264,7 +4245,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "superagent": {
@@ -4273,16 +4254,16 @@
       "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
-        "debug": "3.1.0",
-        "extend": "3.0.1",
-        "form-data": "2.3.1",
-        "formidable": "1.1.1",
-        "methods": "1.1.2",
-        "mime": "1.6.0",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.3"
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.1.1",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.0.5"
       },
       "dependencies": {
         "debug": {
@@ -4300,9 +4281,9 @@
           "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "mime": {
@@ -4323,7 +4304,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "~1.30.0"
           }
         },
         "ms": {
@@ -4346,8 +4327,8 @@
       "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
       "dev": true,
       "requires": {
-        "methods": "1.1.2",
-        "superagent": "3.8.2"
+        "methods": "~1.1.2",
+        "superagent": "^3.0.0"
       }
     },
     "supports-color": {
@@ -4356,7 +4337,7 @@
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "tap": {
@@ -4365,25 +4346,25 @@
       "integrity": "sha1-36w+zxSshUe7rSW70Wzyw3Q/Zc8=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.0",
-        "clean-yaml-object": "0.1.0",
-        "color-support": "1.1.3",
-        "coveralls": "2.13.1",
-        "deeper": "2.1.0",
-        "foreground-child": "1.5.6",
-        "glob": "7.1.2",
-        "isexe": "1.1.2",
-        "js-yaml": "3.9.1",
-        "nyc": "7.1.0",
-        "only-shallow": "1.2.0",
-        "opener": "1.4.3",
+        "bluebird": "^3.3.1",
+        "clean-yaml-object": "^0.1.0",
+        "color-support": "^1.1.0",
+        "coveralls": "^2.11.2",
+        "deeper": "^2.1.0",
+        "foreground-child": "^1.3.3",
+        "glob": "^7.0.0",
+        "isexe": "^1.0.0",
+        "js-yaml": "^3.3.1",
+        "nyc": "^7.1.0",
+        "only-shallow": "^1.0.2",
+        "opener": "^1.4.1",
         "os-homedir": "1.0.1",
-        "readable-stream": "2.3.3",
-        "signal-exit": "3.0.2",
-        "stack-utils": "0.4.0",
-        "tap-mocha-reporter": "2.0.1",
-        "tap-parser": "2.2.3",
-        "tmatch": "2.0.1"
+        "readable-stream": "^2.0.2",
+        "signal-exit": "^3.0.0",
+        "stack-utils": "^0.4.0",
+        "tap-mocha-reporter": "^2.0.0",
+        "tap-parser": "^2.2.0",
+        "tmatch": "^2.0.1"
       },
       "dependencies": {
         "glob": {
@@ -4392,12 +4373,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -4406,7 +4387,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "nyc": {
@@ -4415,31 +4396,31 @@
           "integrity": "sha1-jhSXHzoV0au+x6xhDvVMuInp/7Q=",
           "dev": true,
           "requires": {
-            "arrify": "1.0.1",
-            "caching-transform": "1.0.1",
-            "convert-source-map": "1.3.0",
-            "default-require-extensions": "1.0.0",
-            "find-cache-dir": "0.1.1",
-            "find-up": "1.1.2",
-            "foreground-child": "1.5.3",
-            "glob": "7.0.5",
-            "istanbul-lib-coverage": "1.0.0-alpha.4",
-            "istanbul-lib-hook": "1.0.0-alpha.4",
-            "istanbul-lib-instrument": "1.1.0-alpha.4",
-            "istanbul-lib-report": "1.0.0-alpha.3",
-            "istanbul-lib-source-maps": "1.0.0-alpha.10",
-            "istanbul-reports": "1.0.0-alpha.8",
-            "md5-hex": "1.3.0",
-            "micromatch": "2.3.11",
-            "mkdirp": "0.5.1",
-            "pkg-up": "1.0.0",
-            "resolve-from": "2.0.0",
-            "rimraf": "2.5.4",
-            "signal-exit": "3.0.0",
-            "spawn-wrap": "1.2.4",
-            "test-exclude": "1.1.0",
-            "yargs": "4.8.1",
-            "yargs-parser": "2.4.1"
+            "arrify": "^1.0.1",
+            "caching-transform": "^1.0.0",
+            "convert-source-map": "^1.3.0",
+            "default-require-extensions": "^1.0.0",
+            "find-cache-dir": "^0.1.1",
+            "find-up": "^1.1.2",
+            "foreground-child": "^1.5.3",
+            "glob": "^7.0.3",
+            "istanbul-lib-coverage": "^1.0.0-alpha.4",
+            "istanbul-lib-hook": "^1.0.0-alpha.4",
+            "istanbul-lib-instrument": "^1.1.0-alpha.3",
+            "istanbul-lib-report": "^1.0.0-alpha.3",
+            "istanbul-lib-source-maps": "^1.0.0-alpha.10",
+            "istanbul-reports": "^1.0.0-alpha.8",
+            "md5-hex": "^1.2.0",
+            "micromatch": "^2.3.11",
+            "mkdirp": "^0.5.0",
+            "pkg-up": "^1.0.0",
+            "resolve-from": "^2.0.0",
+            "rimraf": "^2.5.4",
+            "signal-exit": "^3.0.0",
+            "spawn-wrap": "^1.2.4",
+            "test-exclude": "^1.1.0",
+            "yargs": "^4.8.1",
+            "yargs-parser": "^2.4.1"
           },
           "dependencies": {
             "align-text": {
@@ -4448,9 +4429,9 @@
               "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
               "dev": true,
               "requires": {
-                "kind-of": "3.0.3",
-                "longest": "1.0.1",
-                "repeat-string": "1.5.4"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
               }
             },
             "amdefine": {
@@ -4483,7 +4464,7 @@
               "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
               "dev": true,
               "requires": {
-                "arr-flatten": "1.0.1"
+                "arr-flatten": "^1.0.1"
               }
             },
             "arr-flatten": {
@@ -4516,10 +4497,10 @@
               "integrity": "sha1-kHLdI1P7D4W2tX0sl/DRNNGIrtg=",
               "dev": true,
               "requires": {
-                "babel-runtime": "6.9.2",
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "2.0.0"
+                "babel-runtime": "^6.0.0",
+                "chalk": "^1.1.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^2.0.0"
               }
             },
             "babel-generator": {
@@ -4528,12 +4509,12 @@
               "integrity": "sha1-FPaTOrsgxiZm0n47e59bncBxKpo=",
               "dev": true,
               "requires": {
-                "babel-messages": "6.8.0",
-                "babel-runtime": "6.9.2",
-                "babel-types": "6.11.1",
-                "detect-indent": "3.0.1",
-                "lodash": "4.13.1",
-                "source-map": "0.5.6"
+                "babel-messages": "^6.8.0",
+                "babel-runtime": "^6.9.0",
+                "babel-types": "^6.10.2",
+                "detect-indent": "^3.0.1",
+                "lodash": "^4.2.0",
+                "source-map": "^0.5.0"
               }
             },
             "babel-messages": {
@@ -4542,7 +4523,7 @@
               "integrity": "sha1-v1BHNsqWfm1l7wrbWipflHyODrk=",
               "dev": true,
               "requires": {
-                "babel-runtime": "6.9.2"
+                "babel-runtime": "^6.0.0"
               }
             },
             "babel-runtime": {
@@ -4551,8 +4532,8 @@
               "integrity": "sha1-1/45G8LMKbgIfB2bOYeJEun8/Vk=",
               "dev": true,
               "requires": {
-                "core-js": "2.4.1",
-                "regenerator-runtime": "0.9.5"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.9.5"
               }
             },
             "babel-template": {
@@ -4561,11 +4542,11 @@
               "integrity": "sha1-lwkPz2vBVoW08FvmXAqUOKp+I+M=",
               "dev": true,
               "requires": {
-                "babel-runtime": "6.9.2",
-                "babel-traverse": "6.11.4",
-                "babel-types": "6.11.1",
-                "babylon": "6.8.4",
-                "lodash": "4.13.1"
+                "babel-runtime": "^6.9.0",
+                "babel-traverse": "^6.9.0",
+                "babel-types": "^6.9.0",
+                "babylon": "^6.7.0",
+                "lodash": "^4.2.0"
               }
             },
             "babel-traverse": {
@@ -4574,15 +4555,15 @@
               "integrity": "sha1-On3vakwf6fWLWcmiK+gfYZ+Cl2w=",
               "dev": true,
               "requires": {
-                "babel-code-frame": "6.11.0",
-                "babel-messages": "6.8.0",
-                "babel-runtime": "6.9.2",
-                "babel-types": "6.11.1",
-                "babylon": "6.8.4",
-                "debug": "2.2.0",
-                "globals": "8.18.0",
-                "invariant": "2.2.1",
-                "lodash": "4.13.1"
+                "babel-code-frame": "^6.8.0",
+                "babel-messages": "^6.8.0",
+                "babel-runtime": "^6.9.0",
+                "babel-types": "^6.9.0",
+                "babylon": "^6.7.0",
+                "debug": "^2.2.0",
+                "globals": "^8.3.0",
+                "invariant": "^2.2.0",
+                "lodash": "^4.2.0"
               }
             },
             "babel-types": {
@@ -4591,11 +4572,11 @@
               "integrity": "sha1-o981W6uQ3c9mMYZAcXzywVTmZIo=",
               "dev": true,
               "requires": {
-                "babel-runtime": "6.9.2",
-                "babel-traverse": "6.11.4",
-                "esutils": "2.0.2",
-                "lodash": "4.13.1",
-                "to-fast-properties": "1.0.2"
+                "babel-runtime": "^6.9.1",
+                "babel-traverse": "^6.9.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.2.0",
+                "to-fast-properties": "^1.0.1"
               }
             },
             "babylon": {
@@ -4604,7 +4585,7 @@
               "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
               "dev": true,
               "requires": {
-                "babel-runtime": "6.9.2"
+                "babel-runtime": "^6.0.0"
               }
             },
             "balanced-match": {
@@ -4619,7 +4600,7 @@
               "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
               "dev": true,
               "requires": {
-                "balanced-match": "0.4.2",
+                "balanced-match": "^0.4.1",
                 "concat-map": "0.0.1"
               }
             },
@@ -4629,9 +4610,9 @@
               "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
               "dev": true,
               "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
               }
             },
             "builtin-modules": {
@@ -4646,9 +4627,9 @@
               "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
               "dev": true,
               "requires": {
-                "md5-hex": "1.3.0",
-                "mkdirp": "0.5.1",
-                "write-file-atomic": "1.1.4"
+                "md5-hex": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "write-file-atomic": "^1.1.4"
               }
             },
             "camelcase": {
@@ -4665,8 +4646,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
               }
             },
             "chalk": {
@@ -4675,11 +4656,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             },
             "cliui": {
@@ -4689,8 +4670,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
               },
               "dependencies": {
@@ -4709,7 +4690,7 @@
               "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.0"
+                "number-is-nan": "^1.0.0"
               }
             },
             "commondir": {
@@ -4742,8 +4723,8 @@
               "integrity": "sha1-glR3SrR4a4xbPPTfumbOVjkywlI=",
               "dev": true,
               "requires": {
-                "lru-cache": "4.0.1",
-                "which": "1.2.10"
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
               }
             },
             "debug": {
@@ -4767,7 +4748,7 @@
               "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
               "dev": true,
               "requires": {
-                "strip-bom": "2.0.0"
+                "strip-bom": "^2.0.0"
               }
             },
             "detect-indent": {
@@ -4776,9 +4757,9 @@
               "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
               "dev": true,
               "requires": {
-                "get-stdin": "4.0.1",
-                "minimist": "1.2.0",
-                "repeating": "1.1.3"
+                "get-stdin": "^4.0.1",
+                "minimist": "^1.1.0",
+                "repeating": "^1.1.0"
               },
               "dependencies": {
                 "minimist": {
@@ -4795,7 +4776,7 @@
               "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
               "dev": true,
               "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
               }
             },
             "escape-string-regexp": {
@@ -4816,7 +4797,7 @@
               "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
               "dev": true,
               "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
               }
             },
             "expand-range": {
@@ -4825,7 +4806,7 @@
               "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
               "dev": true,
               "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
               }
             },
             "extglob": {
@@ -4834,7 +4815,7 @@
               "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             },
             "filename-regex": {
@@ -4849,11 +4830,11 @@
               "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
               "dev": true,
               "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.5",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.5.4"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^1.1.3",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
               }
             },
             "find-cache-dir": {
@@ -4862,9 +4843,9 @@
               "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
               "dev": true,
               "requires": {
-                "commondir": "1.0.1",
-                "mkdirp": "0.5.1",
-                "pkg-dir": "1.0.0"
+                "commondir": "^1.0.1",
+                "mkdirp": "^0.5.1",
+                "pkg-dir": "^1.0.0"
               }
             },
             "find-up": {
@@ -4873,8 +4854,8 @@
               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             },
             "for-in": {
@@ -4889,7 +4870,7 @@
               "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
               "dev": true,
               "requires": {
-                "for-in": "0.1.5"
+                "for-in": "^0.1.5"
               }
             },
             "foreground-child": {
@@ -4898,8 +4879,8 @@
               "integrity": "sha1-lN1qumcTiYZ96OV+mfHC7PsVwBo=",
               "dev": true,
               "requires": {
-                "cross-spawn": "4.0.0",
-                "signal-exit": "3.0.0"
+                "cross-spawn": "^4",
+                "signal-exit": "^3.0.0"
               }
             },
             "fs.realpath": {
@@ -4926,12 +4907,12 @@
               "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.5",
-                "inherits": "2.0.1",
-                "minimatch": "3.0.2",
-                "once": "1.3.3",
-                "path-is-absolute": "1.0.0"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.2",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "glob-base": {
@@ -4940,8 +4921,8 @@
               "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
               "dev": true,
               "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
               }
             },
             "glob-parent": {
@@ -4950,7 +4931,7 @@
               "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
               "dev": true,
               "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.0"
               }
             },
             "globals": {
@@ -4971,10 +4952,10 @@
               "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
               "dev": true,
               "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.7.0"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
               },
               "dependencies": {
                 "source-map": {
@@ -4983,7 +4964,7 @@
                   "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                   "dev": true,
                   "requires": {
-                    "amdefine": "1.0.0"
+                    "amdefine": ">=0.0.4"
                   }
                 }
               }
@@ -4994,7 +4975,7 @@
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               }
             },
             "has-flag": {
@@ -5021,8 +5002,8 @@
               "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
               "dev": true,
               "requires": {
-                "once": "1.3.3",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
@@ -5037,7 +5018,7 @@
               "integrity": "sha1-sJcBBUdmjH4zcCjr6Bbr42yKjVQ=",
               "dev": true,
               "requires": {
-                "loose-envify": "1.2.0"
+                "loose-envify": "^1.0.0"
               }
             },
             "invert-kv": {
@@ -5064,7 +5045,7 @@
               "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
               "dev": true,
               "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
               }
             },
             "is-dotfile": {
@@ -5079,7 +5060,7 @@
               "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
               "dev": true,
               "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
               }
             },
             "is-extendable": {
@@ -5100,7 +5081,7 @@
               "integrity": "sha1-ZDhgPq6+J5OUj/SkJi7I2z1iWXs=",
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.0"
+                "number-is-nan": "^1.0.0"
               }
             },
             "is-fullwidth-code-point": {
@@ -5109,7 +5090,7 @@
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.0"
+                "number-is-nan": "^1.0.0"
               }
             },
             "is-glob": {
@@ -5118,7 +5099,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             },
             "is-number": {
@@ -5127,7 +5108,7 @@
               "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
               "dev": true,
               "requires": {
-                "kind-of": "3.0.3"
+                "kind-of": "^3.0.2"
               }
             },
             "is-posix-bracket": {
@@ -5181,7 +5162,7 @@
               "integrity": "sha1-jFu59vvYUm4K5s9jmvKCZpBrk48=",
               "dev": true,
               "requires": {
-                "append-transform": "0.3.0"
+                "append-transform": "^0.3.0"
               }
             },
             "istanbul-lib-instrument": {
@@ -5190,12 +5171,12 @@
               "integrity": "sha1-d9mxE+n3YaqEmIM5ATpyA6zJitw=",
               "dev": true,
               "requires": {
-                "babel-generator": "6.11.4",
-                "babel-template": "6.9.0",
-                "babel-traverse": "6.11.4",
-                "babel-types": "6.11.1",
-                "babylon": "6.8.4",
-                "istanbul-lib-coverage": "1.0.0-alpha.4"
+                "babel-generator": "^6.11.3",
+                "babel-template": "^6.9.0",
+                "babel-traverse": "^6.9.0",
+                "babel-types": "^6.10.2",
+                "babylon": "^6.8.1",
+                "istanbul-lib-coverage": "^1.0.0-alpha.4"
               }
             },
             "istanbul-lib-report": {
@@ -5204,12 +5185,12 @@
               "integrity": "sha1-MtX27H8zyjpgIgnieLLm/xQ0mK8=",
               "dev": true,
               "requires": {
-                "async": "1.5.2",
-                "istanbul-lib-coverage": "1.0.0-alpha.4",
-                "mkdirp": "0.5.1",
-                "path-parse": "1.0.5",
-                "rimraf": "2.5.4",
-                "supports-color": "3.1.2"
+                "async": "^1.4.2",
+                "istanbul-lib-coverage": "^1.0.0-alpha",
+                "mkdirp": "^0.5.1",
+                "path-parse": "^1.0.5",
+                "rimraf": "^2.4.3",
+                "supports-color": "^3.1.2"
               },
               "dependencies": {
                 "supports-color": {
@@ -5218,7 +5199,7 @@
                   "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
                   "dev": true,
                   "requires": {
-                    "has-flag": "1.0.0"
+                    "has-flag": "^1.0.0"
                   }
                 }
               }
@@ -5229,10 +5210,10 @@
               "integrity": "sha1-mxWlyLWdG5EBviy33VTHA9hq3vE=",
               "dev": true,
               "requires": {
-                "istanbul-lib-coverage": "1.0.0-alpha.4",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.5.4",
-                "source-map": "0.5.6"
+                "istanbul-lib-coverage": "^1.0.0-alpha.0",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.4.4",
+                "source-map": "^0.5.3"
               }
             },
             "istanbul-reports": {
@@ -5241,7 +5222,7 @@
               "integrity": "sha1-CUgw9Mfz1ILkZqrIq9oklfmuRok=",
               "dev": true,
               "requires": {
-                "handlebars": "4.0.5"
+                "handlebars": "^4.0.3"
               }
             },
             "js-tokens": {
@@ -5256,7 +5237,7 @@
               "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.3"
+                "is-buffer": "^1.0.2"
               }
             },
             "lazy-cache": {
@@ -5272,7 +5253,7 @@
               "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
               "dev": true,
               "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
               }
             },
             "load-json-file": {
@@ -5281,11 +5262,11 @@
               "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.4",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
               }
             },
             "lodash": {
@@ -5300,8 +5281,8 @@
               "integrity": "sha1-Cgcx2TWQ3dm6RYn61lqvbuCSF+M=",
               "dev": true,
               "requires": {
-                "lodash.keys": "4.0.7",
-                "lodash.rest": "4.0.3"
+                "lodash.keys": "^4.0.0",
+                "lodash.rest": "^4.0.0"
               }
             },
             "lodash.keys": {
@@ -5328,7 +5309,7 @@
               "integrity": "sha1-aaZarT3lQs9O4PT+dOjjPHCcyw8=",
               "dev": true,
               "requires": {
-                "js-tokens": "1.0.3"
+                "js-tokens": "^1.0.1"
               },
               "dependencies": {
                 "js-tokens": {
@@ -5345,8 +5326,8 @@
               "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
               "dev": true,
               "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.0.0"
+                "pseudomap": "^1.0.1",
+                "yallist": "^2.0.0"
               }
             },
             "md5-hex": {
@@ -5355,7 +5336,7 @@
               "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
               "dev": true,
               "requires": {
-                "md5-o-matic": "0.1.1"
+                "md5-o-matic": "^0.1.1"
               }
             },
             "md5-o-matic": {
@@ -5370,19 +5351,19 @@
               "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
               "dev": true,
               "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.0",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.0.3",
-                "normalize-path": "2.0.1",
-                "object.omit": "2.0.0",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.3"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
               }
             },
             "minimatch": {
@@ -5391,7 +5372,7 @@
               "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.6"
+                "brace-expansion": "^1.0.0"
               }
             },
             "minimist": {
@@ -5421,10 +5402,10 @@
               "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
               "dev": true,
               "requires": {
-                "hosted-git-info": "2.1.5",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.3.0",
-                "validate-npm-package-license": "3.0.1"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
               }
             },
             "normalize-path": {
@@ -5445,8 +5426,8 @@
               "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
               "dev": true,
               "requires": {
-                "for-own": "0.1.4",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.3",
+                "is-extendable": "^0.1.1"
               }
             },
             "once": {
@@ -5455,7 +5436,7 @@
               "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
               "dev": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "optimist": {
@@ -5464,8 +5445,8 @@
               "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
               "dev": true,
               "requires": {
-                "minimist": "0.0.8",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
               }
             },
             "os-homedir": {
@@ -5480,7 +5461,7 @@
               "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
               "dev": true,
               "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
               }
             },
             "parse-glob": {
@@ -5489,10 +5470,10 @@
               "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
               "dev": true,
               "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.2",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
               }
             },
             "parse-json": {
@@ -5501,7 +5482,7 @@
               "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
               "dev": true,
               "requires": {
-                "error-ex": "1.3.0"
+                "error-ex": "^1.2.0"
               }
             },
             "path-exists": {
@@ -5510,7 +5491,7 @@
               "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
               "dev": true,
               "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
               }
             },
             "path-is-absolute": {
@@ -5531,9 +5512,9 @@
               "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.4",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             },
             "pify": {
@@ -5554,7 +5535,7 @@
               "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
               "dev": true,
               "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
               }
             },
             "pkg-dir": {
@@ -5563,7 +5544,7 @@
               "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
               "dev": true,
               "requires": {
-                "find-up": "1.1.2"
+                "find-up": "^1.0.0"
               }
             },
             "pkg-up": {
@@ -5572,7 +5553,7 @@
               "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
               "dev": true,
               "requires": {
-                "find-up": "1.1.2"
+                "find-up": "^1.0.0"
               }
             },
             "preserve": {
@@ -5593,8 +5574,8 @@
               "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
               "dev": true,
               "requires": {
-                "is-number": "2.1.0",
-                "kind-of": "3.0.3"
+                "is-number": "^2.0.2",
+                "kind-of": "^3.0.2"
               }
             },
             "read-pkg": {
@@ -5603,9 +5584,9 @@
               "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
               "dev": true,
               "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.3.5",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
               }
             },
             "read-pkg-up": {
@@ -5614,8 +5595,8 @@
               "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
               "dev": true,
               "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
               }
             },
             "regenerator-runtime": {
@@ -5630,8 +5611,8 @@
               "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
               "dev": true,
               "requires": {
-                "is-equal-shallow": "0.1.3",
-                "is-primitive": "2.0.0"
+                "is-equal-shallow": "^0.1.3",
+                "is-primitive": "^2.0.0"
               }
             },
             "repeat-element": {
@@ -5652,7 +5633,7 @@
               "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
               "dev": true,
               "requires": {
-                "is-finite": "1.0.1"
+                "is-finite": "^1.0.0"
               }
             },
             "require-directory": {
@@ -5680,7 +5661,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
               }
             },
             "rimraf": {
@@ -5689,7 +5670,7 @@
               "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
               "dev": true,
               "requires": {
-                "glob": "7.0.5"
+                "glob": "^7.0.5"
               }
             },
             "semver": {
@@ -5728,12 +5709,12 @@
               "integrity": "sha1-kg6yEadpwJPuv71bDnpdLmirLkA=",
               "dev": true,
               "requires": {
-                "foreground-child": "1.5.3",
-                "mkdirp": "0.5.1",
-                "os-homedir": "1.0.1",
-                "rimraf": "2.5.4",
-                "signal-exit": "2.1.2",
-                "which": "1.2.10"
+                "foreground-child": "^1.3.3",
+                "mkdirp": "^0.5.0",
+                "os-homedir": "^1.0.1",
+                "rimraf": "^2.3.3",
+                "signal-exit": "^2.0.0",
+                "which": "^1.2.4"
               },
               "dependencies": {
                 "signal-exit": {
@@ -5750,7 +5731,7 @@
               "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
               "dev": true,
               "requires": {
-                "spdx-license-ids": "1.2.1"
+                "spdx-license-ids": "^1.0.2"
               }
             },
             "spdx-exceptions": {
@@ -5765,8 +5746,8 @@
               "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
               "dev": true,
               "requires": {
-                "spdx-exceptions": "1.0.5",
-                "spdx-license-ids": "1.2.1"
+                "spdx-exceptions": "^1.0.4",
+                "spdx-license-ids": "^1.0.0"
               }
             },
             "spdx-license-ids": {
@@ -5781,9 +5762,9 @@
               "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.0.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             },
             "strip-ansi": {
@@ -5792,7 +5773,7 @@
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               }
             },
             "strip-bom": {
@@ -5801,7 +5782,7 @@
               "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
               "dev": true,
               "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
               }
             },
             "supports-color": {
@@ -5816,11 +5797,11 @@
               "integrity": "sha1-9d3XGJJ7Ev0C8nCgqpOc627qQVE=",
               "dev": true,
               "requires": {
-                "arrify": "1.0.1",
-                "lodash.assign": "4.0.9",
-                "micromatch": "2.3.11",
-                "read-pkg-up": "1.0.1",
-                "require-main-filename": "1.0.1"
+                "arrify": "^1.0.1",
+                "lodash.assign": "^4.0.9",
+                "micromatch": "^2.3.8",
+                "read-pkg-up": "^1.0.1",
+                "require-main-filename": "^1.0.1"
               }
             },
             "to-fast-properties": {
@@ -5836,10 +5817,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "async": "0.2.10",
-                "source-map": "0.5.6",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "async": "~0.2.6",
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
               },
               "dependencies": {
                 "async": {
@@ -5856,9 +5837,9 @@
                   "dev": true,
                   "optional": true,
                   "requires": {
-                    "camelcase": "1.2.1",
-                    "cliui": "2.1.0",
-                    "decamelize": "1.2.0",
+                    "camelcase": "^1.0.2",
+                    "cliui": "^2.1.0",
+                    "decamelize": "^1.0.0",
                     "window-size": "0.1.0"
                   }
                 }
@@ -5877,8 +5858,8 @@
               "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
               "dev": true,
               "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.2"
+                "spdx-correct": "~1.0.0",
+                "spdx-expression-parse": "~1.0.0"
               }
             },
             "which": {
@@ -5887,7 +5868,7 @@
               "integrity": "sha1-kc2b0HUTIkEbZZtA8FSyHelXqy0=",
               "dev": true,
               "requires": {
-                "isexe": "1.1.2"
+                "isexe": "^1.1.1"
               }
             },
             "which-module": {
@@ -5915,7 +5896,7 @@
               "integrity": "sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8=",
               "dev": true,
               "requires": {
-                "string-width": "1.0.1"
+                "string-width": "^1.0.1"
               }
             },
             "wrappy": {
@@ -5930,9 +5911,9 @@
               "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.4",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
+                "graceful-fs": "^4.1.2",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
               }
             },
             "y18n": {
@@ -5953,20 +5934,20 @@
               "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
               "dev": true,
               "requires": {
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.1",
-                "lodash.assign": "4.0.9",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.1",
-                "which-module": "1.0.0",
-                "window-size": "0.2.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "2.4.1"
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "lodash.assign": "^4.0.3",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.1",
+                "which-module": "^1.0.0",
+                "window-size": "^0.2.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^2.4.1"
               },
               "dependencies": {
                 "cliui": {
@@ -5975,9 +5956,9 @@
                   "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                   "dev": true,
                   "requires": {
-                    "string-width": "1.0.1",
-                    "strip-ansi": "3.0.1",
-                    "wrap-ansi": "2.0.0"
+                    "string-width": "^1.0.1",
+                    "strip-ansi": "^3.0.1",
+                    "wrap-ansi": "^2.0.0"
                   }
                 },
                 "window-size": {
@@ -5994,8 +5975,8 @@
               "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
               "dev": true,
               "requires": {
-                "camelcase": "3.0.0",
-                "lodash.assign": "4.0.9"
+                "camelcase": "^3.0.0",
+                "lodash.assign": "^4.0.6"
               },
               "dependencies": {
                 "camelcase": {
@@ -6016,15 +5997,15 @@
       "integrity": "sha1-xwMWFz1uOhbFjhupLV1s2N5YoS4=",
       "dev": true,
       "requires": {
-        "color-support": "1.1.3",
-        "debug": "2.1.3",
-        "diff": "1.4.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "js-yaml": "3.9.1",
-        "readable-stream": "2.3.3",
-        "tap-parser": "2.2.3",
-        "unicode-length": "1.0.3"
+        "color-support": "^1.1.0",
+        "debug": "^2.1.3",
+        "diff": "^1.3.2",
+        "escape-string-regexp": "^1.0.3",
+        "glob": "^7.0.5",
+        "js-yaml": "^3.3.1",
+        "readable-stream": "^2.1.5",
+        "tap-parser": "^2.0.0",
+        "unicode-length": "^1.0.0"
       },
       "dependencies": {
         "escape-string-regexp": {
@@ -6039,12 +6020,12 @@
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -6053,7 +6034,7 @@
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -6064,9 +6045,9 @@
       "integrity": "sha1-rebpbje/04zg8WLaBn80A08GiwE=",
       "dev": true,
       "requires": {
-        "events-to-array": "1.1.2",
-        "js-yaml": "3.9.1",
-        "readable-stream": "2.3.3"
+        "events-to-array": "^1.0.1",
+        "js-yaml": "^3.2.7",
+        "readable-stream": "^2"
       }
     },
     "text-encoding": {
@@ -6103,8 +6084,8 @@
       "resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.0.tgz",
       "integrity": "sha1-UimZDtGVMHi3ZhKuN5x9F/wzOUs=",
       "requires": {
-        "lodash.isnull": "3.0.0",
-        "validate.io-undefined": "1.0.3"
+        "lodash.isnull": "^3.0.0",
+        "validate.io-undefined": "^1.0.3"
       }
     },
     "to-string-x": {
@@ -6112,7 +6093,7 @@
       "resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.0.tgz",
       "integrity": "sha1-ILqWObX8wFBUTRkmBHRv2CXOXFE=",
       "requires": {
-        "is-symbol": "1.0.1"
+        "is-symbol": "^1.0.1"
       }
     },
     "token-stream": {
@@ -6125,7 +6106,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
       "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "tough-cookie": {
@@ -6133,7 +6114,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "traverse-chain": {
@@ -6147,8 +6128,8 @@
       "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-1.3.3.tgz",
       "integrity": "sha1-4lbiSCKUke3w0ITvYwoH7whhTAA=",
       "requires": {
-        "to-string-x": "1.4.0",
-        "white-space-x": "2.0.2"
+        "to-string-x": "^1.4.0",
+        "white-space-x": "^2.0.2"
       }
     },
     "trim-right-x": {
@@ -6156,8 +6137,8 @@
       "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-1.3.2.tgz",
       "integrity": "sha1-tEWI1ok9zqC9hbRRzRYI6URSvrA=",
       "requires": {
-        "to-string-x": "1.4.0",
-        "white-space-x": "2.0.2"
+        "to-string-x": "^1.4.0",
+        "white-space-x": "^2.0.2"
       }
     },
     "trim-x": {
@@ -6165,8 +6146,8 @@
       "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-1.0.2.tgz",
       "integrity": "sha1-n+URzd3PzlaCWfx3sZJ/vCmafxQ=",
       "requires": {
-        "trim-left-x": "1.3.3",
-        "trim-right-x": "1.3.2"
+        "trim-left-x": "^1.3.3",
+        "trim-right-x": "^1.3.2"
       }
     },
     "tunnel-agent": {
@@ -6174,7 +6155,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -6189,11 +6170,11 @@
       "integrity": "sha1-JAhTh1WsXd+X9G88BabRdPImIng=",
       "requires": {
         "deprecate": "1.0.0",
-        "jsonwebtoken": "7.4.3",
+        "jsonwebtoken": "^7.4.1",
         "lodash": "4.0.0",
         "moment": "2.18.1",
-        "q": "2.0.3",
-        "request": "2.81.0",
+        "q": "2.0.x",
+        "request": "2.81.x",
         "rootpath": "0.1.2",
         "scmp": "0.0.3",
         "xmlbuilder": "9.0.1"
@@ -6209,9 +6190,9 @@
           "resolved": "https://registry.npmjs.org/q/-/q-2.0.3.tgz",
           "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
           "requires": {
-            "asap": "2.0.6",
-            "pop-iterate": "1.0.1",
-            "weak-map": "1.0.5"
+            "asap": "^2.0.0",
+            "pop-iterate": "^1.0.1",
+            "weak-map": "^1.0.5"
           }
         }
       }
@@ -6228,7 +6209,7 @@
       "integrity": "sha1-uTaKWTzG730GReeLL0xky+zQXpA=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.0.14"
+        "mime-types": "~2.0.9"
       }
     },
     "typedarray-to-buffer": {
@@ -6236,7 +6217,7 @@
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.2.tgz",
       "integrity": "sha1-EBezLZhP9VbroQD1AViauhrOLgQ=",
       "requires": {
-        "is-typedarray": "1.0.0"
+        "is-typedarray": "^1.0.0"
       }
     },
     "uglify-js": {
@@ -6244,9 +6225,9 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -6273,8 +6254,8 @@
       "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1",
-        "strip-ansi": "3.0.1"
+        "punycode": "^1.3.2",
+        "strip-ansi": "^3.0.1"
       }
     },
     "universal-analytics": {
@@ -6282,10 +6263,10 @@
       "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.4.15.tgz",
       "integrity": "sha1-SrxhsVn/52W+FE4Ht7c54O57iKs=",
       "requires": {
-        "async": "1.2.1",
-        "request": "2.81.0",
-        "underscore": "1.7.0",
-        "uuid": "3.1.0"
+        "async": "1.2.x",
+        "request": "2.x",
+        "underscore": "1.x",
+        "uuid": "^3.0.0"
       }
     },
     "universalify": {
@@ -6329,9 +6310,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -6352,7 +6333,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "watson-developer-cloud": {
@@ -6360,19 +6341,19 @@
       "resolved": "https://registry.npmjs.org/watson-developer-cloud/-/watson-developer-cloud-2.39.0.tgz",
       "integrity": "sha1-ZNufx+8YIOGtecVqEYXhkjYGqkI=",
       "requires": {
-        "async": "2.5.0",
-        "buffer-from": "0.1.1",
-        "cookie": "0.3.1",
-        "csv-stringify": "1.0.4",
-        "extend": "3.0.1",
-        "isstream": "0.1.2",
-        "object.omit": "2.0.1",
-        "object.pick": "1.2.0",
-        "request": "2.81.0",
-        "solr-client": "0.7.0",
+        "async": "^2.5.0",
+        "buffer-from": "^0.1.1",
+        "cookie": "~0.3.1",
+        "csv-stringify": "~1.0.2",
+        "extend": "~3.0.0",
+        "isstream": "~0.1.2",
+        "object.omit": "~2.0.0",
+        "object.pick": "~1.2.0",
+        "request": "~2.81.0",
+        "solr-client": "^0.7.0",
         "string": "3.3.3",
-        "vcap_services": "0.3.4",
-        "websocket": "1.0.24"
+        "vcap_services": "~0.3.0",
+        "websocket": "~1.0.22"
       },
       "dependencies": {
         "async": {
@@ -6380,7 +6361,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
           "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "cookie": {
@@ -6400,10 +6381,10 @@
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.24.tgz",
       "integrity": "sha1-dJA+dfJUW2suHeFCW8HJBZF6GJA=",
       "requires": {
-        "debug": "2.6.8",
-        "nan": "2.7.0",
-        "typedarray-to-buffer": "3.1.2",
-        "yaeti": "0.0.6"
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
       },
       "dependencies": {
         "debug": {
@@ -6427,7 +6408,7 @@
       "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       },
       "dependencies": {
         "isexe": {
@@ -6453,12 +6434,12 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
       "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
       "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
       },
       "dependencies": {
         "async": {
@@ -6473,8 +6454,8 @@
       "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
       "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
       "requires": {
-        "acorn": "3.3.0",
-        "acorn-globals": "3.1.0"
+        "acorn": "^3.1.0",
+        "acorn-globals": "^3.0.0"
       }
     },
     "wordwrap": {
@@ -6493,48 +6474,6 @@
       "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.3.9.tgz",
       "integrity": "sha1-bxPsNRRTF+spLKX2UxORskQRFBE=",
       "dev": true
-    },
-    "xml2json": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/xml2json/-/xml2json-0.11.0.tgz",
-      "integrity": "sha1-HVTx2GjbvQSJK4RdfLrZTFKOFuQ=",
-      "requires": {
-        "hoek": "4.2.0",
-        "joi": "9.2.0",
-        "node-expat": "2.3.16"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-        },
-        "isemail": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-          "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
-        },
-        "joi": {
-          "version": "9.2.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
-          "integrity": "sha1-M4WseQGSEwy+Iw6ALsAskhW7/to=",
-          "requires": {
-            "hoek": "4.2.0",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "moment": "2.18.1",
-            "topo": "2.0.2"
-          }
-        },
-        "topo": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-          "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
-      }
     },
     "xmlbuilder": {
       "version": "9.0.1",
@@ -6562,9 +6501,9 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     }

--- a/test/bustracker_unit_test.js
+++ b/test/bustracker_unit_test.js
@@ -10,13 +10,16 @@ const moment    = require('moment-timezone')
 
 const bustracker            = require('../lib/bustracker')
     , { URL }               = require('url')
-    , muniURL               = new URL(config.MUNI_URL)
     , responses             = require('./fixtures/muniResponse')
     , gtfs                  = require('../lib/gtfs')
     , stopNumber            = 3
 
 describe('Bustracker Module', function() {
-    before(function(){ nock.disableNetConnect()})
+    let muniURL
+    before(function(){ 
+        muniURL= new URL(gtfs.stop_number_url[stopNumber])
+        nock.disableNetConnect()
+    })
     after(function(){ nock.enableNetConnect()})
 
     describe('With a good Muni response', function(){
@@ -24,7 +27,7 @@ describe('Bustracker Module', function() {
         const startTime = 100
         beforeEach(function() {
             nockscope = nock(muniURL.origin).get(muniURL.pathname)
-            .query({stopid: gtfs.stop_number_lookup[stopNumber]})
+            .query({stopid: muniURL.searchParams.get('stopid')})
             .reply(200, responses.goodResponse )
             clock = sinon.useFakeTimers({now: startTime})
             get = bustracker.getStopFromStopNumber(stopNumber)
@@ -72,7 +75,7 @@ describe('Bustracker Module', function() {
         beforeEach(function() {
             logstub = sinon.stub(logger, 'error')
             nockscope = nock(muniURL.origin).get(muniURL.pathname)
-                        .query({stopid: gtfs.stop_number_lookup[stopNumber]})
+                        .query({stopid: muniURL.searchParams.get('stopid')})
         })
         afterEach(function(){
             logstub.restore()

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -10,7 +10,6 @@ const nock             = require('nock')
 const app              = require('../app')
 const config           = require('../lib/config')
 const { URL }          = require('url')
-
 const http             = require('http')
 const logger           = require('../lib/logger')
 const moment           = require('moment-timezone')

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -10,7 +10,7 @@ const nock             = require('nock')
 const app              = require('../app')
 const config           = require('../lib/config')
 const { URL }          = require('url')
-const muniURL          = new URL(config.MUNI_URL)
+
 const http             = require('http')
 const logger           = require('../lib/logger')
 const moment           = require('moment-timezone')
@@ -24,6 +24,7 @@ const crypto           = require('crypto')
 const gtfs             = require('../lib/gtfs');
 
 let request = supertest(app)
+const stopNumber = 2051
 
 // wait until GTFS has loaded and parsed
 gtfs.GTFS_Check.on("ready", run)
@@ -31,9 +32,10 @@ gtfs.GTFS_Check.on("ready", run)
 app.enable('view cache')
 
 describe("Integration Tests", function(){
-    let clock;
+    let clock, muniURL;
 
     before(function(){
+        muniURL = new URL(gtfs.stop_number_url[stopNumber])
         // If today is a bus holiday move day 
         while (gtfs.serviceExceptions()){
             clock =  sinon.useFakeTimers(moment().add(1, 'days').tz(config.TIMEZONE).valueOf())
@@ -148,15 +150,14 @@ describe("Integration Tests", function(){
             })
 
             it('Should deliver stops to SMS requests with stop number', function(done){
-                const stop_number = "2051"
-                nock(muniURL.origin).get(muniURL.pathname).query({stopid: 1477}).reply(200, muniResponses.goodResponse )
+                nock(muniURL.origin).get(muniURL.pathname).query({stopid: muniURL.searchParams.get('stopid')}).reply(200, muniResponses.goodResponse )
 
                 request.post('/')
-                .send({Body: stop_number})
+                .send({Body: stopNumber})
                 .expect(/^\* Stop/)
                 .expect((res) =>{
                     var lines = res.text.split('\n')
-                    assert(lines[0].includes(stop_number), "Results didn't include the stop number")
+                    assert(lines[0].includes(stopNumber), "Results didn't include the stop number")
                     assert.equal(lines[2],  '10 Northern Lights - Outbound - ')
                     assert.equal(lines[3],  '4:52 PM')
                 })
@@ -189,11 +190,10 @@ describe("Integration Tests", function(){
             })
 
             it('Should pass message to user when muni site is down', function(done){
-                const stop_number = "2051"
-                nock(muniURL.origin).get(muniURL.pathname).query({stopid: 1477}).reply(404 )
+                nock(muniURL.origin).get(muniURL.pathname).query({stopid: muniURL.searchParams.get('stopid')}).reply(404 )
 
                 request.post('/')
-                .send({Body: stop_number})
+                .send({Body: stopNumber})
                 .expect(/Bustracker is down/)
                 .end((err, res) => done(err))
             })
@@ -235,11 +235,10 @@ describe("Integration Tests", function(){
             })
 
             it('Should deliver stops from requests with stop number', function(done){
-                const stop_number = "2051"
-                nock(muniURL.origin).get(muniURL.pathname).query({stopid: "1477"}).reply(200, muniResponses.goodResponse )
+                nock(muniURL.origin).get(muniURL.pathname).query({stopid:  muniURL.searchParams.get('stopid')}).reply(200, muniResponses.goodResponse )
 
                 request.post('/ajax')
-                .send({Body: stop_number})
+                .send({Body: stopNumber})
                 .expect(/<div .* 2051/)
                 .expect(/DOWNTOWN TRANSIT CENTER/)
                 .expect(/Mountain View/)
@@ -272,11 +271,10 @@ describe("Integration Tests", function(){
             })
 
             it('Should report error when muni site is down', function(done){
-                const stop_number = "2051"
-                nock(muniURL.origin).get(muniURL.pathname).query({stopid: "1477"}).reply(404)
+                nock(muniURL.origin).get(muniURL.pathname).query({stopid:  muniURL.searchParams.get('stopid')}).reply(404)
 
                 request.post('/ajax')
-                .send({Body: stop_number})
+                .send({Body: stopNumber})
                 .expect(/<div.*Bustracker is down/)
                 .end((err, res) => done(err))
             })
@@ -311,9 +309,9 @@ describe("Integration Tests", function(){
             })
 
             it('Should send full webpage with results for URL query with stop number', function(done){
-                nock(muniURL.origin).get(muniURL.pathname).query({stopid: "1477"}).reply(200, muniResponses.goodResponse )
+                nock(muniURL.origin).get(muniURL.pathname).query({stopid:  muniURL.searchParams.get('stopid')}).reply(200, muniResponses.goodResponse )
 
-                request.get('/find/2051')
+                request.get('/find/' + stopNumber)
                 .expect(/^<!DOCTYPE/)
                 .expect(/DOWNTOWN TRANSIT CENTER/)
                 .expect(/Northern Lights/)
@@ -526,11 +524,10 @@ describe("Integration Tests", function(){
 
         it('Should log SMS requests to private db', function(done){
             const from = "testPhone: " + Date.now().toString(8).slice(3)
-            const stop = "2051"
-            const nockscope = nock(muniURL.origin).get(muniURL.pathname).query({stopid: "1477"}).reply(200, muniResponses.goodResponse )
+            const nockscope = nock(muniURL.origin).get(muniURL.pathname).query({stopid:  muniURL.searchParams.get('stopid')}).reply(200, muniResponses.goodResponse )
             nock("http://www.google-analytics.com")
             request.post('/')
-            .send({Body: stop, From: from})
+            .send({Body: stopNumber, From: from})
             .end((err, res) => {
                 if (err) done(err)
                 logger.on('logging', (res) => {
@@ -553,12 +550,11 @@ describe("Integration Tests", function(){
 
         it('Should log SMS requests to public db', function(done){
             const from = "testPhone: " + Date.now().toString(8).slice(3)
-            const stop = "2051"
             nock("http://www.google-analytics.com")
-            const nockscope = nock(muniURL.origin).get(muniURL.pathname).query({stopid: "1477"}).reply(200, muniResponses.goodResponse )
+            const nockscope = nock(muniURL.origin).get(muniURL.pathname).query({stopid: muniURL.searchParams.get('stopid')}).reply(200, muniResponses.goodResponse )
 
             request.post('/')
-            .send({Body: stop, From: from})
+            .send({Body: stopNumber, From: from})
             .end((err, res) => {
                 if (err) done(err)
                 logger.on('logging', (res) => {


### PR DESCRIPTION
This removes dependence on the non-standard `bt_id` field in the `stops.txt` GTFS file based on a recommendation from Danny at the Muni. We have been using the `bt_id` to construct the muni URL to lookup stop info, but that url already exists in the same file as `stop_url`. It's a very small change, but with that change there is no need to have the config variable `MUNI_URL`, so that has been removed here. These changed broke a handful of tests that were constructing urls based on `MUNI_URL`. These should all be changed to use the url in the GTFS. 