### PR TITLE
Update places api

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -8,7 +8,7 @@ module.exports = {
     GOOGLE_GEOCODE_LOCATION: "Anchorage, Alaska",
     GOOGLE_PLACES_KEY: process.env.GOOGLE_PLACES_KEY || 'fake_google_goecode_key',
 
-    GEOCODE_URL_BASE: "https://maps.googleapis.com/maps/api/place/textsearch/json?",
+    GEOCODE_URL_BASE: "https://maps.googleapis.com/maps/api/place/findplacefromtext/json?",
 
     TIMEZONE: "America/Anchorage",
     LOG_DAYS_BACK: 5,

--- a/lib/geocode.js
+++ b/lib/geocode.js
@@ -68,13 +68,18 @@ function stops_near_location(address){
  * @returns {promise<{location: string, formatted_addess: string}>}
  */
 function getGeocodedAddress(address) {
-    // TODO: what happens when we reach the free limit?
     const CITY = encodeURIComponent(config.GOOGLE_GEOCODE_LOCATION)
-    const COUNTRY = "US"
     const timer = Date.now();
     return new Promise((resolve, reject) => {
         const query = encodeURIComponent(address)
-        request(`${config.GEOCODE_URL_BASE}query=${query}&location=61.2181%2C-149.9003&radius=20000&region=US&key=${config.GOOGLE_PLACES_KEY}`, function(error, response, body){
+        const goecode_options = [
+            `input=${query}%20${CITY}`,
+            'fields=formatted_address,name,types,geometry',
+            'inputtype=textquery',
+            'locationbias=circle:20000@61.2181%2C-149.9003',
+            `key=${config.GOOGLE_PLACES_KEY}`
+        ]
+        request(config.GEOCODE_URL_BASE + goecode_options.join('&'), function(error, response, body){
             if (!error && response.statusCode == 200) {
                 const geocodeData = JSON.parse(body)
                 if (geocodeData.status != "OK") {
@@ -82,24 +87,10 @@ function getGeocodedAddress(address) {
                            ? reject(new NotFoundError("Address Not Found"))
                            : reject(new GeocoderError(geocodeData.status))
                 }
-                // filterning on types can help reduce noise
-                const acceptable_types = [
-                    'route',
-                    'street_address',
-                    'intersection',
-                    'transit_station',
-                    'point_of_interest',
-                    'establishment',
-                    'train_station',
-                    'bus_station',
-                    'neighborhood',
-                    'premise'
-                ]
-                const result = geocodeData.results[0]
-                const data = (result.types && acceptable_types.some(el => result.types.includes(el)))
-                    ? {location:result.geometry.location, formatted_address: result.formatted_address}
-                    : null
-
+                
+                const result = geocodeData.candidates[0]
+                const data = {location:result.geometry.location, formatted_address: result.name}
+               
                 resolve({data: data, asyncTime: Date.now()-timer})
 
             } else {

--- a/test/fixtures/googleMapsResponses.js
+++ b/test/fixtures/googleMapsResponses.js
@@ -1,112 +1,60 @@
 exports.goodResponse = {
-    html_attributions:[],
-    results : [
-        {
-            formatted_address: "632 W 6th Ave, Anchorage, AK 99501",
-            geometry: {
-                location: {
-                    lat: 61.2163327,
-                    lng: -149.8948618
-                },
-                viewport: {
-                    northeast:{
-                        lat: 61.21781182989272,
-                        lng: -149.8934942201073
-                    },
-                    southwest:{
-                        lat: 61.21511217010728,
-                        lng: -149.8961938798927
-                    }
-                }
-            },
-            icon: "https://maps.gstatic.com/mapfiles/place_api/icons/geocode-71.png",
-            id: "4633048423a3dcbc97da6a5a5aae8795d9f59237",
-            name: "632 W 6th Ave",
-            place_id: "ChIJ80XfroC9yFYRb4ltnt-cwc0",
-            reference: "CmRbAAAAUxzueVAkaGav2owv6hAGofLiY7ZOsCbbjmb59TrXRVgy5Qq60P_HUn3PJG_35pz8ftuJp_tO3sxasVGewF3aTsvx5j5hLAYwgTXsBYSWmOyplW3inSJd0x2br9vcb1-kEhD7QwB9W_itZhYa7WxIHc8LGhTBpQm8q5vKa-l2JS-DvanHQUljXw",
-            types:["premise"]
-        }
-    ],
-    status:"OK"
-}
-
- exports.glennAlpsLocation = {
-    "results" : [
+    "candidates" : [
        {
-          "address_components" : [
-             {
-                "long_name" : "13735",
-                "short_name" : "13735",
-                "types" : [ "street_number" ]
-             },
-             {
-                "long_name" : "Canyon Road",
-                "short_name" : "Canyon Rd",
-                "types" : [ "route" ]
-             },
-             {
-                "long_name" : "Glen Alps",
-                "short_name" : "Glen Alps",
-                "types" : [ "neighborhood", "political" ]
-             },
-             {
-                "long_name" : "Anchorage",
-                "short_name" : "Anchorage",
-                "types" : [ "locality", "political" ]
-             },
-             {
-                "long_name" : "Anchorage",
-                "short_name" : "Anchorage",
-                "types" : [ "administrative_area_level_2", "political" ]
-             },
-             {
-                "long_name" : "Alaska",
-                "short_name" : "AK",
-                "types" : [ "administrative_area_level_1", "political" ]
-             },
-             {
-                "long_name" : "United States",
-                "short_name" : "US",
-                "types" : [ "country", "political" ]
-             },
-             {
-                "long_name" : "99516",
-                "short_name" : "99516",
-                "types" : [ "postal_code" ]
-             }
-          ],
-          "formatted_address" : "13735 Canyon Rd, Anchorage, AK 99516, USA",
+          "formatted_address" : "632 W 6th Ave",
           "geometry" : {
-             "bounds" : {
-                "northeast" : {
-                   "lat" : 61.09634800000001,
-                   "lng" : -149.7103882
-                },
-                "southwest" : {
-                   "lat" : 61.09633889999999,
-                   "lng" : -149.7103895
-                }
-             },
              "location" : {
-                "lat" : 61.09634800000001,
-                "lng" : -149.7103882
+                "lat" : 61.21632990000001,
+                "lng" : -149.8948221
              },
-             "location_type" : "RANGE_INTERPOLATED",
              "viewport" : {
                 "northeast" : {
-                   "lat" : 61.0976924302915,
-                   "lng" : -149.7090398697085
+                   "lat" : 61.21781042989273,
+                   "lng" : -149.8934750701073
                 },
                 "southwest" : {
-                   "lat" : 61.0949944697085,
-                   "lng" : -149.7117378302915
+                   "lat" : 61.21511077010728,
+                   "lng" : -149.8961747298927
                 }
              }
           },
-          "place_id" : "EikxMzczNSBDYW55b24gUmQsIEFuY2hvcmFnZSwgQUsgOTk1MTYsIFVTQQ",
+          "name" : "632 W 6th Ave",
+          "types" : [ "premise" ]
+       }
+    ],
+    "debug_log" : {
+       "line" : []
+    },
+    "status" : "OK"
+ }
+
+ exports.glennAlpsLocation = {
+    "candidates" : [
+       {
+          "formatted_address" : "13735 Canyon Rd, Anchorage, AK 99516, USA",
+          "geometry" : {
+             "location" : {
+                "lat" : 61.09633889999999,
+                "lng" : -149.7103895
+             },
+             "viewport" : {
+                "northeast" : {
+                   "lat" : 61.09768872989272,
+                   "lng" : -149.7090396701073
+                },
+                "southwest" : {
+                   "lat" : 61.09498907010727,
+                   "lng" : -149.7117393298927
+                }
+             }
+          },
+          "name" : "13735 Canyon Rd",
           "types" : [ "street_address" ]
        }
     ],
+    "debug_log" : {
+       "line" : []
+    },
     "status" : "OK"
  }
 
@@ -115,66 +63,12 @@ exports.goodResponse = {
  }
 
  // nonspecific responses are what happens when the geocoder doesn't
- // find the specific address. It just returns coordinates for the city
+ // find the specific address. It just returns empty resuts
  exports.nonspecificResponse = {
-    "results" : [
-       {
-          "address_components" : [
-             {
-                "long_name" : "Anchorage",
-                "short_name" : "Anchorage",
-                "types" : [ "locality", "political" ]
-             },
-             {
-                "long_name" : "Anchorage",
-                "short_name" : "Anchorage",
-                "types" : [ "administrative_area_level_2", "political" ]
-             },
-             {
-                "long_name" : "Alaska",
-                "short_name" : "AK",
-                "types" : [ "administrative_area_level_1", "political" ]
-             },
-             {
-                "long_name" : "United States",
-                "short_name" : "US",
-                "types" : [ "country", "political" ]
-             }
-          ],
-          "formatted_address" : "Anchorage, AK, USA",
-          "geometry" : {
-             "bounds" : {
-                "northeast" : {
-                   "lat" : 61.48393789999999,
-                   "lng" : -148.460007
-                },
-                "southwest" : {
-                   "lat" : 60.733791,
-                   "lng" : -150.4206149
-                }
-             },
-             "location" : {
-                "lat" : 61.2180556,
-                "lng" : -149.9002778
-             },
-             "location_type" : "APPROXIMATE",
-             "viewport" : {
-                "northeast" : {
-                   "lat" : 61.48389109999999,
-                   "lng" : -148.4600069
-                },
-                "southwest" : {
-                   "lat" : 60.733791,
-                   "lng" : -150.2862832
-                }
-             }
-          },
-          "partial_match" : true,
-          "place_id" : "ChIJQT-zBHaRyFYR42iEp1q6fSU",
-          "types" : [ "locality", "political" ]
-       }
-    ],
-    "status" : "OK"
+    "candidates" : [],
+    "debug_log" : {
+       "line" : []
+    },
+    "status" : "ZERO_RESULTS"
  }
-
  exports.badRequest = {statusCode: 403}

--- a/test/geocode_unit_test.js
+++ b/test/geocode_unit_test.js
@@ -10,6 +10,7 @@ const gtfs       = require('../lib/gtfs')
 const { URL }    = require('url')
 const GoogleURL  = new URL(config.GEOCODE_URL_BASE)
 
+
 gtfs.GTFS_Check.on("ready", run)
 
 describe('Geocode Module', function() {
@@ -22,14 +23,11 @@ describe('Geocode Module', function() {
     it('Should request the correct Google Maps API URL', function(){
         const address = '632 W. 6th Street'
         const n = nock(GoogleURL.origin).get(GoogleURL.pathname)
-            .query({
-                query: address, // nock seems to URI encode this for us
-                location: `61.2181,-149.9003`,
-                radius: '20000',
-                region:'US',
-                key: config.GOOGLE_PLACES_KEY
-            })
-            .reply(200, responses.goodResponse)
+        .query(function(queryObject){
+           return queryObject.input === `${address} ${config.GOOGLE_GEOCODE_LOCATION}`
+        })
+        .reply(200, responses.goodResponse) 
+
 
         return geocode.stops_near_location(address)
         .then(r => n.done(), err => n.done())
@@ -43,7 +41,7 @@ describe('Geocode Module', function() {
         })
         it('Should return a geocoded address', function(){
             return get_stops
-                .then(resp => assert.equal(resp.data.geocodedAddress, responses.goodResponse.results[0].formatted_address))
+                .then(resp => assert.equal(resp.data.geocodedAddress, responses.goodResponse.candidates[0].formatted_address))
         })
         it('Should return stops that have a numeric stopId property', function(){
             return get_stops.then(resp => assert(resp.data.stops.every(stop => /^\d+$/.test(stop.stopId))))

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -22,6 +22,8 @@ const hashwords        = require('hashwords')()
 const crypto           = require('crypto')
 const gtfs             = require('../lib/gtfs');
 
+const GoogleURL  = new URL(config.GEOCODE_URL_BASE)
+
 let request = supertest(app)
 const stopNumber = 2051
 
@@ -166,13 +168,9 @@ describe("Integration Tests", function(){
             it('Should deliver nearest stops to SMS requests with address ', function(done){
                 const address = "632 W 6th Ave"
 
-                nock('https://maps.googleapis.com').get('/maps/api/place/textsearch/json')
-                .query({
-                    query: address, // nock seems to URI encode this for us
-                    location: `61.2181,-149.9003`,
-                    radius: '20000',
-                    region:'US',
-                    key: config.GOOGLE_PLACES_KEY
+                nock(GoogleURL.origin).get(GoogleURL.pathname)
+                .query(function(queryObject){
+                    return queryObject.input === `${address} ${config.GOOGLE_GEOCODE_LOCATION}`
                 })
                 .reply(200, geocodeResponses.goodResponse)
 
@@ -247,13 +245,9 @@ describe("Integration Tests", function(){
             it('Should deliver nearest stops to requests with address ', function(done){
                 const address = "632 W 6th Ave"
 
-                nock('https://maps.googleapis.com').get('/maps/api/place/textsearch/json')
-                .query({
-                    query: address, // nock seems to URI encode this for us
-                    location: `61.2181,-149.9003`,
-                    radius: '20000',
-                    region:'US',
-                    key: config.GOOGLE_PLACES_KEY
+                nock(GoogleURL.origin).get(GoogleURL.pathname)
+                .query(function(queryObject){
+                    return queryObject.input === `${address} ${config.GOOGLE_GEOCODE_LOCATION}`
                 })
                 .reply(200, geocodeResponses.goodResponse)
 
@@ -320,13 +314,9 @@ describe("Integration Tests", function(){
             it('Should send full webpage with results for URL query with address', function(done){
                 const address = '5th and G street'
 
-                nock('https://maps.googleapis.com').get('/maps/api/place/textsearch/json')
-                .query({
-                    query: address, // nock seems to URI encode this for us
-                    location: `61.2181,-149.9003`,
-                    radius: '20000',
-                    region:'US',
-                    key: config.GOOGLE_PLACES_KEY
+                nock(GoogleURL.origin).get(GoogleURL.pathname)
+                .query(function(queryObject){
+                    return queryObject.input === `${address} ${config.GOOGLE_GEOCODE_LOCATION}`
                 })
                 .reply(200, geocodeResponses.goodResponse)
 


### PR DESCRIPTION
Move places search from old (and potentially expensive) `textsearch` call to newer `findplacefromtext` call.  Added small refactor to make url options more readable. Adjusted tests and fixtures to reflect places api change.