### PR TITLE
fix typo in lowdb Async module import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "8"
+  - "10"

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -4,7 +4,7 @@ const config = require('./config')
 const crypto = require('crypto')
 const fs = require('fs')
 const low = require('lowdb')
-const FileASync = require('lowdb/adapters/FileASync')
+const FileASync = require('lowdb/adapters/FileAsync')
 
 const request = require('request')
 const logger = require('./logger')

--- a/lib/lowdb_log_transport.js
+++ b/lib/lowdb_log_transport.js
@@ -2,7 +2,7 @@
 
 const util        = require('util')
 const low         = require('lowdb')
-const FileASync = require('lowdb/adapters/FileASync')
+const FileASync = require('lowdb/adapters/FileAsync')
 
 const moment      = require('moment-timezone')
 const winston     = require('winston')

--- a/test/feedback_unit_test.js
+++ b/test/feedback_unit_test.js
@@ -8,7 +8,7 @@ const feedback  = require('../lib/feedback')
 const comments  = require('./fixtures/fake_comments.json')
 const logger    = require('../lib/logger')
 const twilioClient = feedback.twilioClient
-const FileASync = require('lowdb/adapters/FileASync')
+const FileASync = require('lowdb/adapters/FileAsync')
 
 
 describe("User Feedback", function(){

--- a/test/lowdbLog_unit_test.js
+++ b/test/lowdbLog_unit_test.js
@@ -13,7 +13,7 @@ const winston   = require('winston')
 const hashwords = require('hashwords')()
 const config    = require('../lib/config')
 const lowdb_log = require('../lib/lowdb_log_transport')
-const FileASync = require('lowdb/adapters/FileASync')
+const FileASync = require('lowdb/adapters/FileAsync')
 
 describe('LowDB Log Transport', function(){
     let logger, lowdbStub


### PR DESCRIPTION
Ugh, mac fs is not case sensitive for module imports, so it worked locally, but not on production.