### PR TITLE
Mmeyer read stop code

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -34,5 +34,7 @@ module.exports = {
     // after the current time. This setting allows a buffer of minutes to show 
     // buses that might be late. Set to 3, this will show buses scheduled to arrive
     // at 2:00 until 2:03.
-    LATE_DELAY_TIME: 2
+    LATE_DELAY_TIME: 2,
+
+    GTFS_FILE: process.env.GTFS_FILE || 'People_Mover.gtfs.zip'
 }

--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -10,7 +10,7 @@ const EventEmitter  = require('events')
 const raw_directory = (__dirname + '/../gtfs/raw/')
 
 const muni_URL  = "http://gtfs.muni.org/"
-const gtfs_file = "People_Mover_2020.01.14.gtfs.zip"
+const gtfs_file = config.GTFS_FILE
 
 /* These are the files from the GTFS zip we need to run the app */
 const requiredFiles = ['stops.txt', 'calendar_dates.txt']

--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -5,13 +5,12 @@ const fs            = require('fs-extra')
 const child_process = require('child_process')
 const parse         = require('csv-parse')
 const config        = require('./config')
-const request       = require('request')
 const moment        = require('moment-timezone')
 const EventEmitter  = require('events')
 const raw_directory = (__dirname + '/../gtfs/raw/')
 
 const muni_URL  = "http://gtfs.muni.org/"
-const gtfs_file = "People_Mover.gtfs.zip"
+const gtfs_file = "People_Mover_2020.01.14.gtfs.zip"
 
 /* These are the files from the GTFS zip we need to run the app */
 const requiredFiles = ['stops.txt', 'calendar_dates.txt']
@@ -125,7 +124,7 @@ class WatchedFile {
                     return first_run ? reject(err) : resolve();
                 }
                 // The gtfs files have a header row that will be used for object keys
-                parse(data, {columns:true}, (err, output) => {
+                parse(data, {columns:true, ltrim:true}, (err, output) => {
                     if (err) {
                         logger.error(err);
                         return first_run ? reject(err) : resolve();
@@ -152,7 +151,7 @@ class Stops extends WatchedFile {
         }
         this.stop_url = {}
         data.forEach((point) => {
-            this.stop_url[parseInt(point.stop_id)] = point.stop_url
+            this.stop_url[parseInt(point.stop_code)] = point.stop_url
         })
     }
 }
@@ -162,7 +161,7 @@ function makeGeoJSONPoint(point){
         "type": "Feature",
         "properties": {
             "name": point.stop_name,
-            "stop_id": point.stop_id,
+            "stop_id": point.stop_code,
             "stop_url": point.stop_url
         },
         "geometry": {
@@ -193,7 +192,7 @@ logger.debug("Checking that GTFS files are available ")
 
 fs.ensureDir(raw_directory)
 .then(getGTFSFile)
-.then(() => Promise.all([all_stops, exceptions].map(i=>i.init())))
+.then(() => Promise.all([all_stops, exceptions].map(i => i.init())))
 .then(() => GTFS_Check.emit("ready"))
 .catch(err => {
     logger.error(err)

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -162,7 +162,7 @@ describe("Integration Tests", function(){
                     var lines = res.text.split('\n')
                     assert(lines[0].includes(stopNumber), "Results didn't include the stop number")
                     assert.equal(lines[2],  '10 Northern Lights - Outbound - ')
-                    assert.equal(lines[3],  '5:09 PM, 5:23 PM')
+                    assert.equal(lines[3],  '4:58 PM, 5:23 PM')
                 })
                 .end((err, res) => done(err))
             })


### PR DESCRIPTION
This uses the `stop_code` rather than `stop_id` from stops.txt. This field is meant to be the public facing code specifically for things like text apps. This will free `stop_id` to be used as an arbitrary key. 

This also sets the flag on `csv-parse` to ignore white space after a comma in csv values. This fixes issues with header names like `" stop_url"` 

This moves where the GTFS file is specified out of the source code into env. To set, add 

`GTFS_FILE: "People_Mover_2020.01.14.gtfs.zip"`

to the ecosystem. This will prevent changes to the source code from interfering with updating with git. If the env variable is not set, this will default to `People_Mover.gtfs.zip`