### PR TITLE
Update API endpoint for IBM Watson

### DIFF
--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -209,7 +209,7 @@ async function askWatson(req, res, next){
         authenticator: new IamAuthenticator({
             apikey: config.WATSON_API_KEY,
         }),
-        url: "https://gateway.watsonplatform.net/assistant/api",
+        url: "https://api.us-south.assistant.watson.cloud.ibm.com"
     })
 
     // Saving the sessionID in a cookie and passing it back allows the conversation


### PR DESCRIPTION
IBM has changed the API for services including Watson Assistant. This changes the API  per:

> To avoid any interruption in service please update your code to use the new api.{location}.{offering}.watson.cloud.ibm.com URL for all your Watson instances. For additional details on how to find and update the URL, please checkout our Docs or contact us by opening a support case here.

It looks like `us-south` is currently the closest location.