### PR TITLE
Update gtft https

### DIFF
--- a/lib/bustracker.js
+++ b/lib/bustracker.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const config = require('./config')
-const http = require('http')
+const http = require('https')
 const logger = require('./logger')
 const gtfs = require('./gtfs')
 const moment = require('moment-timezone')

--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -9,7 +9,7 @@ const moment        = require('moment-timezone')
 const EventEmitter  = require('events')
 const raw_directory = (__dirname + '/../gtfs/raw/')
 
-const muni_URL  = "http://gtfs.muni.org/"
+const muni_URL  = "https://gtfs.muni.org/"
 const gtfs_file = config.GTFS_FILE
 
 /* These are the files from the GTFS zip we need to run the app */

--- a/test/integration_test.js
+++ b/test/integration_test.js
@@ -442,7 +442,7 @@ describe("Integration Tests", function(){
             })
 
             it("Should accept multiple requests and respond to each individually", function(done){
-                nock('http://bustracker.muni.org').get(muniURL.pathname).query(true).times(4).reply(200, muniResponses.goodResponse )
+                nock('https://bustracker.muni.org').get(muniURL.pathname).query(true).times(4).reply(200, muniResponses.goodResponse )
 
                 let nocks = []
                 facebookMessage.multiple.entry.forEach(entry =>  entry.messaging.forEach(message => {
@@ -466,7 +466,7 @@ describe("Integration Tests", function(){
             })
 
             it("Should pass error messages on to user", function(done){
-                nock('http://bustracker.muni.org').get(muniURL.pathname).times(4).query(true).reply(404)
+                nock('https://bustracker.muni.org').get(muniURL.pathname).times(4).query(true).reply(404)
 
                 let nocks = []
                 facebookMessage.multiple.entry.forEach(entry =>  entry.messaging.forEach(message => {


### PR DESCRIPTION
- Updates the gtfs url to use https
- Updates the code to use the node `https` library when requesting bus tracker urls

This will require the URLS in the GTFS stops.txt file to now be https urls.
